### PR TITLE
split long lines to avoid use of -ffree-line-length-none

### DIFF
--- a/src/Atoms/atmos_type.f90
+++ b/src/Atoms/atmos_type.f90
@@ -55,9 +55,9 @@ module atmos_type
 	real(kind=dp) :: B_char = 0d0, v_char=0d0
            !B_char in Tesla and v_char in m/s, default 0T and 1km/s
 	logical :: lMagnetized = .false., calc_ne, laccretion_shock
-	
+
 	real(kind=dp) :: thetai, thetao
-	
+
 	integer, allocatable, dimension(:) :: icompute_atomRT!
 	real(kind=dp), dimension(:), allocatable :: xmu, wmu, xmux, xmuy
 	!removed the depency in rays of some quantity (like phi_loc or I) since rate matrix
@@ -2311,7 +2311,7 @@ module atmos_type
 		write(*,*) "Read ", size(pack(icompute_atomRT,mask=icompute_atomRT>0)), " density zones"
 		write(*,*) "Read ", size(pack(icompute_atomRT,mask=icompute_atomRT==0)), " transparent zones"
 		write(*,*) "Read ", size(pack(icompute_atomRT,mask=icompute_atomRT<0)), " dark zones"
-		
+
 !old way of setting geometrical structures onto the stellar surface. Using stars.f90/intersect_spots and etoile(1)%SurfB
 !-> future deprecation
 !-> not used anymore, to be removed (kept for checking accretion spot with old routines)
@@ -2330,16 +2330,16 @@ module atmos_type
 ! !     thetao = asin(sqrt(1d0/3d0))
 ! !    end if
 ! 			Lr = Ggrav * etoile(1)%M * Msun_to_kg * Msun /3.154e7  / (etoile(1)%r*au_to_m) * (1. - 2./(rmi + rmo))
-! 
-! 
+!
+!
 ! 			write(*,*) "Angles at stellar surface (deg)", thetao*rad_to_deg, thetai*rad_to_deg
 ! 			Tring = Lr / (4d0 * PI * (etoile(1)%r*au_to_m)**2 * sigma * abs(cos(thetai)-cos(thetao)))
 ! 			Tring = Tring**0.25
 ! 			write(*,*) " Accretion spots tilt (deg)", tilt*180./pi
 
 ! 			if (Tshk > 0) Tring = Tshk
-! 
-! 
+!
+!
 ! 			!2 is for two rings, 2Pi is dphi from 0 to 2pi / total sphere surface
 ! 			write(*,*) "Ring T ", Tring, "K"
 ! 			write(*,*) "Surface ", 100*(abs(cos(thetai)-cos(thetao))), "%" !couverte par les deux anneaux sur toute la sphere
@@ -2437,7 +2437,8 @@ module atmos_type
 		enddo icell_loop
 		N_fixed_ne = size(pack(icompute_atomRT,mask=(icompute_atomRT==2)))
 		if (N_fixed_ne > 0) then
-			write(*,'("Found "(1I5)" cells with fixed electron density values! ("(1I3)" %)")') N_fixed_ne, nint(real(N_fixed_ne) / real(n_cells) * 100)
+			write(*,'("Found "(1I5)" cells with fixed electron density values! ("(1I3)" %)")') &
+            N_fixed_ne, nint(real(N_fixed_ne) / real(n_cells) * 100)
 		endif
 
 	!no need if we do not the dark_zones from input file.

--- a/src/Atoms/collision.f90
+++ b/src/Atoms/collision.f90
@@ -73,7 +73,7 @@ module collision
 		end if
 
 		return
-		
+
 	end function fone
 
 	function ftwo(x) result(y)
@@ -324,7 +324,7 @@ module collision
 
 		return
 	end function summers
-	
+
 	function collision_rates_atom_loc(icell, atom, deriv) result(C)
 	! --------------------------------------------------------------------------- !
 	! Computes collisional rates and fills the C matrix.
@@ -340,7 +340,7 @@ module collision
 	! The function then reads this array at each cell to compute
 	! the collisional rates. This is not very efficient as interpolation
 	! are done on the fly. Still, it avoids storing the full collision matrix
-	! in memory and the time to compute the collisional rates is negligible 
+	! in memory and the time to compute the collisional rates is negligible
 	! compared to the time to integrate the RTE.
 	! --------------------------------------------------------------------------- !
 		type (AtomType), intent(inout) :: atom
@@ -559,7 +559,7 @@ module collision
 ! 				stop
 ! 			end if
 
-			
+
 			! -- END of reading data for key, now computing collision rates -- !
 			! Still in the loop over the lines in the atomic file.
 
@@ -571,19 +571,19 @@ module collision
 
             	!here Nitem is NTMP !
             	if (Nitem /= NTMP) call error("Error, Nitem should be NTMP!")
-            	
+
 !             	CC = interp_dp(coeff, TGRID, T(icell))
             	!if coeff and TGRID are not allocatables,
             	!the size of coeff and Tgrid must be given (otherwise interpolation errors appear) !
 				CC = interp_dp(coeff(1:Nitem), TGRID(1:Nitem), T(icell))
 
 			end if
-			
+
 			!Compute also the derivative if present.
 			!note that in principle ni_bb / nj_cont is prop to ne and
 			!ne * phi(T) should be use because LTE populations are updated afterwards
 			!not during the electron + SEE iterations. See impact.f90 and see_ionisation_nonlte in statequil_atom.f90 for more details.
-			
+
 			if (key.eq."OMEGA") then
 				! -- Collisional excitation of ions
 				!Cdown means from j->i
@@ -610,8 +610,8 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 * Cdown/ne(icell)
      				deriv(i,j) = deriv(i,j) + Cdown * atom%nstar(j,icell)/atom%nstar(i,icell) / ne(icell)
-     			endif   
-      
+     			endif
+
 			else if (key.eq."CI") then
 			! -- Collisional ionisation
 				deltaE = atom%E(j) - atom%E(i)
@@ -620,20 +620,20 @@ module collision
 				!write(*,*) "dE=",deltaE," exp()=",exp(-deltaE/(KBOLTZMANN*T(k)))
 				C(i,j) = C(i,j) + Cup
 				C(j,i) = C(j,i) + Cup * atom%nstar(i,icell)/atom%nstar(j,icell)
-      
+
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * Cup * atom%nstar(i,icell)/atom%nstar(j,icell)
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif     
-      
+     			endif
+
 			else if (key.eq."CR") then
 			! -- Collisional de-excitation by electrons
 				Cdown = ne(icell) * CC
 				C(j,i) = C(j,i) + Cdown !here
-				
+
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * cdown
-     			endif 
+     			endif
 
 			else if (key.eq."CP") then
 			! -- collisions with protons
@@ -645,7 +645,7 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 * Cdown/ne(icell)
      				deriv(i,j) = deriv(i,j) + Cdown * atom%nstar(j,icell)/atom%nstar(i,icell) / ne(icell)
-     			endif     
+     			endif
 			else if (key.eq."CH") then
 			! -- Collisions with neutral hydrogen
 				Cup = Hydrogen%n(1,icell) * CC
@@ -654,20 +654,20 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * Cup * atom%nstar(i,icell)/atom%nstar(j,icell)
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
+     			endif
 			else if (key.eq."CH0") then
 			! -- Charge exchange with neutral hydrogen
 				C(j,i) = C(j,i) + Hydrogen%n(1,icell)*CC
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * Hydrogen%n(1,icell)*CC
-     			endif 
+     			endif
 			else if (key.eq."CH+") then
 			! -- charge exchange with protons
 				np = Hydrogen%n(Hydrogen%Nlevel,icell)
 				C(i,j) = C(i,j) + np*CC
      			if (present(deriv)) then
      				deriv(i,j) = deriv(i,j) + np*CC/ne(icell)
-     			endif 
+     			endif
 			else if (key.eq."SHULL82") then
 				acolsh = coeff(1)
 				tcolsh = coeff(2)
@@ -693,7 +693,7 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0*cdn / ne(icell)
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
+     			endif
 			else if (key.eq."BADNELL") then
 			! -- Fit for dielectronic recombination form Badnell
 			! First line coefficients are energies in K (from Chianti)
@@ -719,8 +719,8 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * cdn
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
-     			
+     			endif
+
 ! 				deallocate(badi)
 			else if (key.eq."AR85-CDI") then
 			! -- Direct collisional ionisation
@@ -747,7 +747,7 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * cdn
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
+     			endif
 ! 				deallocate(cdi)
 			else if (key.eq."AR85-CEA") then
 			! -- Autoionisation
@@ -760,7 +760,7 @@ module collision
 				!  " C[ji,k]=",C(ji,k)
      			if (present(deriv)) then
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
+     			endif
 			else if (key.eq."AR85-CHP") then
 			! -- Charge transfer with ionised Hydrogen
 				ar85t1 = coeff(1)
@@ -771,11 +771,13 @@ module collision
 				ar85d = coeff(6)
 				if ((T(icell) >= ar85t1).and.(T(icell) <= ar85t2)) then
 					t4 = T(icell)/1d4
-					cup = ar85a * 1d-9 * (t4)**(ar85b) * exp(-ar85c*t4) * exp(-ar85d*EV/KBOLTZMANN/T(icell)) * Hydrogen%n(Hydrogen%Nlevel,icell) * (CM_TO_M)**3
+					cup = ar85a * 1d-9 * (t4)**(ar85b) * exp(-ar85c*t4) &
+                     * exp(-ar85d*EV/KBOLTZMANN/T(icell)) &
+                     * Hydrogen%n(Hydrogen%Nlevel,icell) * (CM_TO_M)**3
 					C(i,j) = C(i,j) + cup
      				if (present(deriv)) then
      					deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     				endif 
+     				endif
 				end if
 			else if (key.eq."AR85-CHH") then
 			! Charge transfer with neutral Hydrogen
@@ -791,7 +793,7 @@ module collision
 					C(j,i) = C(j,i) + cdn
      				if (present(deriv)) then
      					deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * cdn
-     				endif 
+     				endif
 				end if
 			else if (key.eq."BURGESS") then
 				write(*,*) "BURGESS NOT CHECK"
@@ -816,16 +818,16 @@ module collision
      			if (present(deriv)) then
      				deriv(j,i) = deriv(j,i) + 2.0 / ne(icell) * cdn
      				deriv(i,j) = deriv(i,j) + Cup / ne(icell)
-     			endif 
+     			endif
 			end if
-   
+
 		end do loop_lines_in_file
 
 ! 		deallocate(TGRID, coeff)
 
 		return
 	end function collision_rates_atom_loc
- 
+
 ! FUNCTION CollisionRate_old(icell, atom) result(C)
 !  ! -------------------------------------------------------------
 !  ! Computes collisional rates and fills the C matrix.
@@ -856,7 +858,7 @@ module collision
 !   real(8) :: t0sh, t1sh, summrs, tg, cdn, ccup
 !   real(8) :: ar85t1, ar85t2, ar85a, ar85b, ar85c, ar85d, t4
 !   real(8) :: de,zz,betab,cbar,dekt,dekti,wlog,wb,sumscl=0.0
-! 
+!
 !   ! -- Nitem2 is here to check
 !   ! that Nitem (read) is equals to the acutla number
 !   ! of item read Nitem2
@@ -864,19 +866,19 @@ module collision
 !   ! because it reads in an array of size Nitem, so
 !   ! Nitem are expected to be read and an error will be
 !   ! raise otherwise.
-! 
+!
 !   write(FormatLine,'("(1"A,I3")")') "A", MAX_LENGTH
-! 
+!
 !   C0 = ((E_RYDBERG/sqrt(M_ELECTRON)) * PI*SQ(RBOHR)) * sqrt(8.0/(PI*KBOLTZMANN))
-! 
+!
 !   ! -- Initialise the collisional matrix at each cell--
 !   C(:,:) = 0d0
 !   Nlines = size(atom%collision_lines)
-! 
+!
 !   key="        "
 !   ! -- Go throught the remaining lines in the file --
 !   ! read collisional data depending the cases of recipes.
-! 
+!
 !   !do while(key.ne.END_OF_FILE)
 !   do k1=1, Nlines
 !    countline = countline + 1
@@ -890,7 +892,7 @@ module collision
 !    ! for the interpolation of the coefficients
 !    ! you have to modify the file to flush right
 !    ! everything after the TEMP keyword.
-! 
+!
 !    key = adjustl(inputline(1:len(key)))
 !    !write(*,*) trim(inputline)
 !    !write(*,*) "Line = ", countline, " key=",key,"."
@@ -901,17 +903,17 @@ module collision
 !     allocate(TGRID(NTMP))
 !     ! Nread is len(NTMP) in string format, offset
 !     ! inputline to read TGRID only, after NTMP.
-! 
+!
 !     read(inputline(len(key)+3:Nread),*) (TGRID(k), k=1,NTMP)
 !     !write(*,*) (TGRID(k), k=1,NTMP)
 !     Nitem = NTMP
 !     Nitem2 = size(TGRID)
-! 
+!
 !    else if ((key.eq."OMEGA") .or. (key.eq."CE") .or.&
 !         (key.eq."CI") .or. (key.eq."CP") .or. &
 !         (key.eq."CH0") .or. (key.eq."CH+") .or. &
 !         (key.eq."CH") .or. (key.eq."CR")) then
-! 
+!
 !     ! -- read level indices and collision coefficients --
 !     Nitem = NTMP
 !     if (allocated(coeff)) deallocate(coeff)
@@ -920,9 +922,9 @@ module collision
 !     ! but read(inputline,*) key, i1, i2, coeff is OK
 !     !write(*,*) key, inputline(len(key)+1:)
 !     read(inputline(len(key)+1:),*) i1, i2,(coeff(k),k=1,Nitem)
-! 
+!
 !     Nitem2 = size(coeff)
-! 
+!
 !     i = MIN(i1,i2) + 1
 !     j = MAX(i1,i2) + 1 !from 1 to Nlevel (in C, 0 to Nlevel-1)
 !     ij = (i-1)*atom%Nlevel + j!j->i
@@ -931,7 +933,7 @@ module collision
 !     ! Cf = C(Nlevel,Nlevel).flatten, of size Nlevel*Nlevel
 !     ! C(i,j) = Cf(ij) = Cf(i*Nlevel + j)
 !     ! C(1,1) = Cf(1) -> i*Nlevel +j = 1 -> i=i-1
-! 
+!
 !    else if ((key.eq."AR85-CHP").or.(key.eq."AR85-CHH")) then
 !     Nitem = 6
 !     if (allocated(coeff)) deallocate(coeff)
@@ -939,46 +941,46 @@ module collision
 !     read(inputline(len(key)+1:),*) i1, i2, &
 !         (coeff(k),k=1,Nitem)
 !     !write(*,*) inputline(len(key)+1:)
-! 
+!
 !     Nitem2 = size(coeff)
-! 
+!
 !     i = MIN(i1,i2) + 1
 !     j = MAX(i1,i2) + 1
 !     ij = (i-1)*atom%Nlevel + j
 !     ji = (j-1)*atom%Nlevel + i
-! 
+!
 !    else if ((key.eq.'AR85-CEA').or.(key.eq."BURGESS")) then
 !      Nitem = 1
 !      if (allocated(coeff)) deallocate(coeff)
 !      allocate(coeff(Nitem))
-! 
+!
 !      read(inputline(len(key)+1:),*) i1, i2, coeff(1)
 !      i = MIN(i1,i2) + 1
 !      j = MAX(i1,i2) + 1
 !      ij = (i-1)*atom%Nlevel + j
 !      ji = (j-1)*atom%Nlevel + i
-! 
+!
 !      Nitem2 = size(coeff)
 !      !write(*,*) "CEA or BURGESS", i1, i2, i, ij
-! 
+!
 !    else if (key.eq."SHULL82") then
 !      Nitem = 8
 !      if (allocated(coeff)) deallocate(coeff)
 !      allocate(coeff(Nitem))
-! 
+!
 !      read(inputline(len(key)+1:),*) i1, i2,&
 !          (coeff(k),k=1,Nitem)
 !      i = MIN(i1,i2) + 1
 !      j = MAX(i1,i2) + 1
 !      ij = (i-1)*atom%Nlevel+j
 !      ji = (j-1)*atom%Nlevel +i
-! 
+!
 !      Nitem2 = size(coeff)
-! 
-! 
+!
+!
 !    else if (key.eq."BADNELL") then
 !     ! -- BADNELL formula for dielectronic recombination --
-! 
+!
 !     !write(*,*) inputline, Nread
 !     read(inputline(len(key)+1:),*) i1, i2, Ncoef
 !     Nrow = 2
@@ -995,9 +997,9 @@ module collision
 !     j = MAX(i1,i2) + 1
 !     ij = atom%Nlevel*(i-1) + j
 !     ji = atom%Nlevel*(j-1) + i
-! 
+!
 !     Nitem2 = size(badi(1,:)) * size(badi(:,1))
-! 
+!
 !    else if (key.eq."SUMMERS") then
 !     ! -- Switch for density dependent DR coefficient
 !     !
@@ -1005,15 +1007,15 @@ module collision
 !     ! density dependence of dielectronic recombination:
 !     ! sumscl = 0. -> no density dependence
 !     ! sumscl = 1. -> full density dependence
-! 
+!
 !     Nitem = 1
 !     read(inputline(len(key)+1:), *) sumscl
-! 
+!
 !     Nitem2 = 1
-! 
+!
 !    else if (key.eq."AR85-CDI") then
 !     read(inputline(len(key)+1:),*) i1, i2, Nrow
-! 
+!
 !     if (Nrow.gt.MSHELL) then
 !      write(*,*) "Nrow is greater than MSHELL, exiting..."
 !      stop
@@ -1022,17 +1024,17 @@ module collision
 !     allocate(cdi(Nrow, MSHELL))
 !     do m=1,Nrow
 !       inputline = atom%collision_lines(k1+m)
-! 
+!
 !       read(inputline,*) (cdi(m,k),k=1,MSHELL)
 !     end do
-! 
+!
 !     Nitem2 = size(cdi(1,:)) * size(cdi(:,1))
-! 
+!
 !     i = MIN(i1,i2) + 1
 !     j = MAX(i1,i2) + 1
 !     ij = (i-1)*atom%Nlevel +j
 !     ji = (j-1)*atom%Nlevel +i
-! 
+!
 !    else if (key.eq.END_OF_FILE) then
 !     exit
 !    else
@@ -1040,7 +1042,7 @@ module collision
 !     write(*,*) "exiting..."
 !     stop
 !    end if ! end over possible cases key
-! 
+!
 !    if (Nitem2 .ne. Nitem) then
 !     ! -- Actually, the error should be in the reading.
 !     write(*,*) "Error, read ", Nitem2," items->expected ", &
@@ -1049,19 +1051,19 @@ module collision
 !     write(*,*) "Exiting..."
 !     stop
 !    end if
-! 
+!
 !    ! -- END of reading, filling now ...
-! 
+!
 !    if ((key.eq."OMEGA") .or. (key.eq."CE") .or. &
 !        (key.eq."CI") .or. (key.eq."CP") .or. &
 !        (key.eq."CH0") .or. (key.eq."CH+") .or. &
 !        (key.eq."CH") .or. (key.eq."CR") ) then
-! 
-! 
+!
+!
 !                       !here Nitem is NTMP !!
 !     !CC = interp1D(TGRID, coeff, T(icell))
 !     CC = interp_dp(coeff, TGRID, T(icell))
-! 
+!
 !    end if
 !    if (key.eq."OMEGA") then
 !     ! -- Collisional excitation of ions
@@ -1165,7 +1167,7 @@ module collision
 !     ! First line coefficients are energies in K (from Chianti)
 !     ! Second line coefficients are coefficients (from Chianti)
 !     ! See Badnell 2006 for more details
-! 
+!
 !     !!do k =1,Nspace
 !      summrs = sumscl*summers(i,j,ne(icell),atom) + &
 !        (1.-sumscl)
@@ -1179,9 +1181,9 @@ module collision
 !      ! -- convert from cm3/s to m3/s
 !      cdn = cdn *ne(icell) * summrs * CUBE(CM_TO_M)
 !      cup = cdn * atom%nstar(j,icell)/atom%nstar(i,icell)
-! 
+!
 !      cdn = cdn + cup*atom%nstar(i,icell)/atom%nstar(j,icell)
-! 
+!
 !      C(j,i) = C(j,i) + cdn
 !      C(i,j) = C(i,j) + cup
 !      !write(*,*) "BADNELL", cdn, cup
@@ -1288,12 +1290,12 @@ module collision
 !     !!end do
 !    end if
 !   end do !loop over (remaining) lines (of the atomic model)
-! 
+!
 !  deallocate(TGRID)
 !  deallocate(coeff)
-! 
+!
 !  RETURN
-!  END FUNCTION CollisionRate_old	
+!  END FUNCTION CollisionRate_old
 end module collision
 
 !-> Futur deprecation, will be computed on the fly, but his routine will be kept

--- a/src/Atoms/io_atomic_pops.f90
+++ b/src/Atoms/io_atomic_pops.f90
@@ -298,7 +298,8 @@ subroutine read_electron(lelectron_read)
 
 	!call FTG2Dd(unit,1,-999,shape(ne),naxes(1),naxes(2),ne,anynull,EOF)
 
-    write(*,'("  -- min(ne)="(1ES20.7E3)" m^-3; max(ne)="(1ES20.7E3)" m^-3")') , minval(ne,mask=(icompute_atomRT>0)), maxval(ne)
+    write(*,'("  -- min(ne)="(1ES20.7E3)" m^-3; max(ne)="(1ES20.7E3)" m^-3")') &
+        minval(ne,mask=(icompute_atomRT>0)), maxval(ne)
 
 return
 end subroutine read_electron
@@ -1112,8 +1113,10 @@ subroutine read_pops_atom(atom)
 			endif
 		enddo
     	write(*,"('Level #'(1I3))") l
-    	write(*,'("  -- min(n)="(1ES20.7E3)" m^-3; max(n)="(1ES20.7E3)" m^-3")') , minval(atom%n(l,:),mask=(icompute_atomRT>0)), maxval(atom%n(l,:))
-    	write(*,'("  -- min(nstar)="(1ES20.7E3)" m^-3; max(nstar)="(1ES20.7E3)" m^-3")')  minval(atom%nstar(l,:),mask=(icompute_atomRT>0)), maxval(atom%nstar(l,:))
+    	write(*,'("  -- min(n)="(1ES20.7E3)" m^-3; max(n)="(1ES20.7E3)" m^-3")') &
+         minval(atom%n(l,:),mask=(icompute_atomRT>0)), maxval(atom%n(l,:))
+    	write(*,'("  -- min(nstar)="(1ES20.7E3)" m^-3; max(nstar)="(1ES20.7E3)" m^-3")') &
+         minval(atom%nstar(l,:),mask=(icompute_atomRT>0)), maxval(atom%nstar(l,:))
 	enddo
 
 

--- a/src/Atoms/math.f90
+++ b/src/Atoms/math.f90
@@ -11,18 +11,18 @@ MODULE math
 	!a verifier. Not useful with Ng ?
 	subroutine solve_lin(A, b, N, minimized)
 		use utils, only : GaussSlv
-		!wrapper around GaussSlv with minimisation of the residual 
+		!wrapper around GaussSlv with minimisation of the residual
 		integer, intent(in) :: N
 		logical, intent(in) :: minimized
 		real(kind=dp), intent(inout) :: A(N,N), b(N)
 		real(kind=dp) :: Adag(N,N), bdag(N), res(N)
 		integer :: i, j
-		
+
 		if (minimized) then
 			bdag = b
 			Adag = A
 		endif
-		
+
 		!get new solutions from A
 		call GaussSlv(A, b, n)
 
@@ -35,17 +35,17 @@ MODULE math
 					res(i) = res(i) - Adag(i,j)*b(j)
 				enddo
 			enddo
-			
+
 			!solve for the residual
 			call Gaussslv(Adag, res, N)
 
 			b(:) = b(:) + res(:)
 		endif
-	
+
 	return
 	end subroutine solve_lin
-	
-	
+
+
 	function Ng_accelerate(niter, solution, m, n, lasts, check_negative_pops)
 		!Extra overheads if check_negative_pops is true
 		use utils, only : GaussSlv
@@ -57,7 +57,7 @@ MODULE math
 		real(kind=dp) :: A(n, n), b(n), w, dy, di,max_sol
 		!!integer, save :: niter
 		!!data niter /0/
-		
+
 		!!niter = niter + 1
 
 		lasts(:,niter) = solution(:)
@@ -65,7 +65,7 @@ MODULE math
 		if (niter <= n+1) return
 
 		A(:,:) = 0.0_dp; b(:) = 0.0_dp
-		
+
 		do k=1, m
 			!what is faster ?
 			if (solution(k) > 0.0) then!fast to check, than doing operations with dy and di zero for all i,j?
@@ -85,26 +85,27 @@ MODULE math
 				enddo
 			endif
 		enddo
-		
+
 		call Gaussslv(A, b, n)
 		!-> no imroved here since the routine is already doing that ?
 		!call solve_lin(A, b, n, .true.)
-		
+
 		!!write(*,*) "b",(b(i), i=1,n)
 		do i=1,n
 			solution(:) = solution(:) + b(i) * ( lasts(:,niter-i) - lasts(:,niter) )
 		enddo
-				
+
 		if (present(check_negative_pops)) then
 
 			max_sol = maxval(solution)
-		
+
 			if (check_negative_pops) then
 				pop_loop : do k=1,m
 					if (solution(k) < 0) then
 						write(*,*) "ERROR negative pops sol in Ng's acceleration"
 						write(*,*) " This is likely to be a bug !"
-						write(*,*) k, "sol:", solution(k), " relative to max:", solution(k)/max_sol, " relative to all:", solution(k) / sum(abs(solution))
+						write(*,*) k, "sol:", solution(k), " relative to max:", &
+                     solution(k)/max_sol, " relative to all:", solution(k) / sum(abs(solution))
 						write(*,*) " leaving..!"
 						stop
 						!better handling ??
@@ -113,17 +114,17 @@ MODULE math
 						!big loop over m inside loop over m. But we exist right after
 						exit pop_loop
 					endif
-				enddo pop_loop	
+				enddo pop_loop
 			endif
-			
+
 		endif
-		
+
 		ng_accelerate = .true.
 		!!if (acc_iter) niter = 0
 
 	return
 	end function ng_accelerate
-		
+
 !-> Building only a simple workaround just for the visibility in atom_transfer.f90. Not crucial.
 ! 	subroutine accelerate(n_iter, Nord, Ndelay, Nperiod, N, current_sol, previous_sols, accel)
 ! 		logical, intent(out) :: accel
@@ -132,8 +133,8 @@ MODULE math
 ! 		logical, save :: ng_rest
 ! 		integer, save :: n_iter_accel = 0
 ! 		integer :: i0_rest, iorder
-! 
-! 					
+!
+!
 ! 		accel = .false.
 ! 		if (n_iter > Ndelay) then
 ! 			iorder = n_iter - Ndelay
@@ -151,8 +152,8 @@ MODULE math
 ! 			ng_rest = .false.
 ! 			i0_rest = 0
 ! 			return
-! 		endif 
-! 				
+! 		endif
+!
 ! 	return
 ! 	end subroutine
 
@@ -162,14 +163,14 @@ MODULE math
 	!to have access to both
 		real(kind=dp) :: test, test2
 		integer, intent(in) :: i
-		
+
 		test = real(i,kind=dp)
 		return
-		
+
 		entry test2(i)
 			test2 = real(i,kind=dp)**2
 		return
-	
+
 	return
 	end function
 
@@ -270,11 +271,11 @@ MODULE math
      do i=1,size(y(:,1))
       do j=1, size(y(1,:))
        if (y(i,j) /= y(i,j)) then
-        write(*,*) "(Nan):", y(i,j), " i=", i, " j=",j 
+        write(*,*) "(Nan):", y(i,j), " i=", i, " j=",j
         val = 1
         return
        else if (y(i,j) > 0 .and. (y(i,j)==y(i,j)*10)) then
-        write(*,*) "(infinity):", y(i,j), y(i,j)*(1+0.1), " i=", i, " j=",j 
+        write(*,*) "(infinity):", y(i,j), y(i,j)*(1+0.1), " i=", i, " j=",j
         val = 2
         return
        end if
@@ -307,7 +308,7 @@ MODULE math
 !    function linear_1D(N,x,y,Np,xp)
 !      real(kind=dp) :: x(N),y(N),linear_1D(Np), xp(Np), t
 !      integer :: N, Np, i, j
-! 
+!
 ! 	 linear_1D(:) = 0.0_dp
 ! !      do i=1,N-1
 ! !         do j=1,Np
@@ -325,11 +326,11 @@ MODULE math
 !            endif
 !         enddo
 !      enddo
-! 
+!
 !      return
-! 
+!
 !    end function linear_1D
-   
+
    function linear_1D_sorted(n,x,y, np,xp)
      ! assumes that both x and xp are in increasing order
      ! We only loop once over the initial array, and we only perform 1 test per element
@@ -410,7 +411,7 @@ MODULE math
 
      return
    end function interp1d_sorted
- 
+
   !not test yet
    function quad_1D_sorted(n,x,y, np,xp)
      ! assumes that both x and xp are in increasing order
@@ -444,7 +445,7 @@ MODULE math
 			  	t = (xp(j) - x(i)) * (xp(j) - x(i+1)) / ((x(i-1) - x(i))*(x(i-1)-x(i+1)) )
 			  	t2 = (xp(j) - x(i-1)) * (xp(j) - x(i+1)) / ((x(i) - x(i-1))*(x(i)-x(i+1)) )
 			    t3 = (xp(j) - x(i-1)) * (xp(j) - x(i)) / ((x(i+1) - x(i-1))*(x(i+2)-x(i)) )
-			  	quad_1D_sorted(j) = quad_1D_sorted(j) + y(i-1)*t + y(i) * t2 + y(i+1) * t3  
+			  	quad_1D_sorted(j) = quad_1D_sorted(j) + y(i-1)*t + y(i) * t2 + y(i+1) * t3
 			  else
               	t = (x(i) - xp(j)) / (x(i) - x(i-1))
               	t2 = (xp(j) - x(i-1)) / (x(i) - x(i-1))
@@ -572,7 +573,7 @@ MODULE math
 
    RETURN
    END FUNCTION dPOW
-   
+
    !approximate exp(-x) = approx_exp_mx(x)
    !x is positive !
    !too slow atm
@@ -580,7 +581,7 @@ MODULE math
    	real(kind=dp), intent(in) :: x
    	real(kind=dp) :: approx_exp_mx
    	integer :: m
-   
+
    	if (x > 500.0) then
    		approx_exp_mx = 0.0 !exp(-(x>650)) -> 0
    	elseif (x < 1d-2) then !exp(-(x<1d-2)) -> taylor
@@ -588,10 +589,10 @@ MODULE math
    	else
    		approx_exp_mx = exp(-x)
    	endif
-   	
+
    return
    end function approx_exp_mx
-   
+
     !interpolation is to slow at the moment to be efficient
 	subroutine exp_lookup (N, argmin,argmax, x, table)
 	!stores a table of tau values (x) and their exp(-tau) (table)
@@ -603,7 +604,7 @@ MODULE math
    		real(kind=dp), dimension(N), intent(out) :: table
    		real(kind=dp), intent(out) :: x(N)
    		integer :: i
-   		
+
    		x(1) = 0.0
    		!include the spanl in a loop ?
    		x(2:N) = spanl(1e-6, argmax, N-1)
@@ -622,7 +623,7 @@ MODULE math
 		real(kind=dp), dimension(4) :: a4, b4
 		real(kind=dp), intent(in) :: x
 		real(kind=dp) :: E1
-		
+
 		a6(:) = 1.0_dp * (/-0.57721566,  0.99999193, -0.24991055,0.05519968, -0.00976004,  0.00107857 /)
 
 		a4(:) = 1.0_dp * (/ 8.5733287401, 18.0590169730, 8.6347608925,  0.2677737343 /)
@@ -644,13 +645,13 @@ MODULE math
 
 	return
 	end function E1
-  
+
 	function E2(x)
 	! second exponential integral, using recurrence relation
 	! En+1 = 1/n * ( exp(-x) -xEn(x))
 		real(kind=dp), intent(in) :: x
 		real(kind=dp) :: E2
-   
+
 		if (x <= 0) then
    			E2 = 0.0_dp
    			return
@@ -664,20 +665,20 @@ MODULE math
 
 	return
 	end function
-	
+
 !   FUNCTION E1 (x) result (y)
 !    !First exponential integral
 !    real, dimension(6) :: a6
 !    real, dimension(4) :: a4, b4
 !    real(kind=dp) :: y, x
-! 
+!
 !    data a6  /-0.57721566,  0.99999193, -0.24991055,&
 !              0.05519968, -0.00976004,  0.00107857 /
 !    data a4  / 8.5733287401, 18.0590169730, &
 !                8.6347608925,  0.2677737343 /
 !    data b4  /9.5733223454, 25.6329561486, &
 !               21.0996530827,  3.9584969228/
-! 
+!
 !    if (x<=0.0) then
 !     write(*,*) "Arg of Exponential integral has to be > 0"
 !     write(*,*) "exiting..."
@@ -694,7 +695,7 @@ MODULE math
 !    else
 !     y = 0.0
 !    end if
-! 
+!
 !   RETURN
 !   END FUNCTION E1
 
@@ -702,7 +703,7 @@ MODULE math
 !   ! second exponential integral, using recurrence relation
 !   ! En+1 = 1/n * ( exp(-x) -xEn(x))
 !    real(kind=dp) :: x, y
-! 
+!
 !    if (x.le.0.) then
 !     write(*,*) "Arg of Exponential integral has to be > 0"
 !     write(*,*) "exiting..."
@@ -712,7 +713,7 @@ MODULE math
 !    else
 !     y = 0.
 !    end if
-! 
+!
 !   RETURN
 !   END FUNCTION
 

--- a/src/Atoms/opacity.f90
+++ b/src/Atoms/opacity.f90
@@ -1,9 +1,10 @@
 module Opacity
 
-  use atmos_type, only								: hydrogen, ntotal_atom, T, ne, NactiveAtoms, Natom, Npassiveatoms, ActiveAtoms, PassiveAtoms, Atoms, Elements, &
-       icompute_atomRT, lmali_scheme, lhogerheijde_scheme, nhtot
+  use atmos_type, only: hydrogen, ntotal_atom, T, ne, NactiveAtoms, Natom, &
+                        Npassiveatoms, ActiveAtoms, PassiveAtoms, Atoms, Elements, &
+                        icompute_atomRT, lmali_scheme, lhogerheijde_scheme, nhtot
   use atom_type
-  use spectrum_type, only								: Itot, Icont, lambda, nlambda, Nlambda_cont, lambda_cont, dk, dk_min, dk_max, &
+  use spectrum_type, only: Itot, Icont, lambda, nlambda, Nlambda_cont, lambda_cont, dk, dk_min, dk_max, &
        chi0_bb, eta0_bb, chi_c, sca_c, eta_c, chi, eta, chi_c_nlte, eta_c_nlte, Jnu_cont, &
        rho_p, etaQUV_p, chiQUV_p
   use constant
@@ -14,13 +15,14 @@ module Opacity
   use voigtfunctions, only							: Voigt
   ! 	use stark, only										: Stark_profile
   use profiles!, only									: Profile
-  use getlambda, only									: hv, Nlambda_max_line, define_local_profile_grid
+  use getlambda, only								: hv, Nlambda_max_line, define_local_profile_grid
   use planck, only 									: bpnu
-  use occupation_probability, only					: wocc_n, D_i
-  ! 	use lte, only 										: phi_T
+  use occupation_probability, only				: wocc_n, D_i
+  ! 	use lte, only 									: phi_T
 
-  use background_opacity, only						: Thomson, Hydrogen_ff, Hminus_bf, Hminus_bf_geltman, &
-       Hminus_bf_geltman, Hminus_bf_Wishart, Hminus_ff_john, Hminus_ff, Hminus_ff_bell_berr, lte_bound_free, H_bf_Xsection
+  use background_opacity, only					: Thomson, Hydrogen_ff, Hminus_bf, Hminus_bf_geltman, &
+                                               Hminus_bf_geltman, Hminus_bf_Wishart, Hminus_ff_john, &
+                                               Hminus_ff, Hminus_ff_bell_berr, lte_bound_free, H_bf_Xsection
   use mcfost_env, only								: dp
   use input, only										: ds
   use molecular_emission, only						: v_proj
@@ -39,7 +41,6 @@ contains
 
     type(AtomType), pointer :: atom
     integer :: n, k, kc, j, alloc_status
-
 
     do n=1,Natom
        atom => Atoms(n)%ptr_atom
@@ -278,8 +279,10 @@ contains
 
                 atom%continua(kc)%alpha(:) = 0d0
                 !computes only where it is not zero
-                atom%continua(kc)%alpha(:) = H_bf_Xsection(atom%continua(kc), lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred))
-                n_eff = atom%stage(atom%continua(kc)%j)*sqrt(atom%Rydberg/(atom%E(atom%continua(kc)%j)-atom%E(atom%continua(kc)%i)))
+                atom%continua(kc)%alpha(:) = H_bf_Xsection(atom%continua(kc), &
+                                                           lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred))
+                n_eff = atom%stage(atom%continua(kc)%j) &
+                        *sqrt(atom%Rydberg/(atom%E(atom%continua(kc)%j)-atom%E(atom%continua(kc)%i)))
                 mem_alloc_local = mem_alloc_local + sizeof(atom%continua(kc)%alpha(:))
              else !interpolation of the read Cross-section
                 !       cont is not an alias but a copy of contiua(kc), so cont%alpha not deallocated
@@ -288,8 +291,10 @@ contains
 
                 !          atom%continua(kc)%alpha(:) = linear_1D(size(atom%continua(kc)%lambda_file),atom%continua(kc)%lambda_file,&
                 !             atom%continua(kc)%alpha_file, atom%continua(kc)%Nlambda,NLTEspec%lambda(atom%continua(kc)%Nblue:atom%continua(kc)%Nred))
-                call bezier3_interp(size(atom%continua(kc)%lambda_file), atom%continua(kc)%lambda_file, atom%continua(kc)%alpha_file, & !read values
-                     atom%continua(kc)%Nlambda, lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred), atom%continua(kc)%alpha) !interpolation grid
+                call bezier3_interp(size(atom%continua(kc)%lambda_file), atom%continua(kc)%lambda_file, &
+                                    atom%continua(kc)%alpha_file, atom%continua(kc)%Nlambda,&
+                                    lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred),&
+                                    atom%continua(kc)%alpha) !interpolation grid
                 mem_alloc_local = mem_alloc_local + sizeof(atom%continua(kc)%alpha(:))
              endif
 
@@ -302,8 +307,9 @@ contains
                 atom%continua(kc)%alpha_nu(:,:) = 0.0_dp
 
                 do icell=1, n_cells_d
-                   call bezier3_interp(size(atom%continua(kc)%alpha), lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred), atom%continua(kc)%alpha, &
-                        size(atom%continua(kc)%alpha_nu(:,icell)), lambda(atom%continua(kc)%Nb:atom%continua(kc)%Nr), atom%continua(kc)%alpha_nu(:,icell))
+                   call bezier3_interp(size(atom%continua(kc)%alpha),lambda_cont(atom%continua(kc)%Nblue:atom%continua(kc)%Nred),&
+                                       atom%continua(kc)%alpha,size(atom%continua(kc)%alpha_nu(:,icell)), &
+                                       lambda(atom%continua(kc)%Nb:atom%continua(kc)%Nr), atom%continua(kc)%alpha_nu(:,icell))
                 enddo
                 mem_alloc_local = mem_alloc_local + sizeof(atom%continua(kc)%alpha_nu(:,:))
 
@@ -384,9 +390,11 @@ contains
 
                 !-> if the profile is not interpolated, a is allocated and adamp is stored in it
                 if (associated(profile,local_profile_interp)) then
-                   atom%lines(kc)%phi(:,icell) = Voigt(size(atom%lines(kc)%u), adamp, atom%lines(kc)%u(:)/vbroad) / (SQRTPI * vbroad)
+                   atom%lines(kc)%phi(:,icell) = Voigt(size(atom%lines(kc)%u), &
+                                                       adamp, atom%lines(kc)%u(:)/vbroad) / (SQRTPI * vbroad)
                 elseif (associated(profile,local_profile_dk)) then !evaluated on the nlte grid
-                   atom%lines(kc)%phi(:,icell) = Voigt(atom%lines(kc)%Nlambda, adamp, (lambda(Nblue:Nred)-atom%lines(kc)%lambda0)/atom%lines(kc)%lambda0 * clight/vbroad) / (SQRTPI * vbroad)
+                   atom%lines(kc)%phi(:,icell) = Voigt(atom%lines(kc)%Nlambda, adamp, &
+                   (lambda(Nblue:Nred)-atom%lines(kc)%lambda0)/atom%lines(kc)%lambda0 * clight/vbroad) / (SQRTPI * vbroad)
 
                    !->these are not kept in memory anymore, only need to store eta(n_cells) but
                    !need also a function that call line_damping and recompute eta from aeff and ratio if necessary!
@@ -406,7 +414,8 @@ contains
                 !! 							atom%lines(kc)%phi(:,icell) = exp(-(atom%lines(kc)%u(:)/atom%vbroad(icell))**2) / (SQRTPI *vbroad)
                 !elseif
                 if (associated(profile,local_profile_dk)) then
-                   atom%lines(kc)%phi(:,icell) = exp(-( (lambda(Nblue:Nred)-atom%lines(kc)%lambda0)/atom%lines(kc)%lambda0 * clight/vbroad )**2 )/ (SQRTPI * vbroad)
+                   atom%lines(kc)%phi(:,icell) = exp(-( (lambda(Nblue:Nred)-atom%lines(kc)%lambda0)&
+                                                     /atom%lines(kc)%lambda0 * clight/vbroad )**2 )/ (SQRTPI * vbroad)
                 endif
              endif !line voigt
 
@@ -421,35 +430,55 @@ contains
                    write(*,"('at cell '(1I9), ' for atom '(1A2), ' line: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
                    write(*,"(' lambda0='(1F12.5)' nm')") atom%lines(kc)%lambda0
                    write(*,"('w(i)='(1ES20.7E3), '; w(j)='(1ES20.7E3))") wi, wj
-                   write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") atom%n(i,icell), atom%n(j,icell), atom%lines(kc)%gij
-                   write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") atom%nstar(i,icell), atom%nstar(j,icell)
+                   write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") &
+                        atom%n(i,icell), atom%n(j,icell), atom%lines(kc)%gij
+                   write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") &
+                        atom%nstar(i,icell), atom%nstar(j,icell)
                    !           						write(*,*) atom%n(i,icell), wi*atom%n(j, icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))!atom%continua(kc)%gij(la, icell)
-                   write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %;',' (n(i)-n(j)gij)/n(j)gij='(1ES20.7E3)' %')") 100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/atom%n(i,icell), 100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/(atom%n(j,icell)*atom%lines(kc)%gij)
-                   write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") 100 * atom%n(i,icell) / ntotal_atom(icell,atom), 100 * atom%n(j,icell) / ntotal_atom(icell,atom)
-                   write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") 100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), 100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
-                   write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") 100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
-                   write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") 100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
+                   write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %;',' (n(i)-n(j)gij)/n(j)gij='(1ES20.7E3)' %')") &
+                        100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/atom%n(i,icell), &
+                        100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/(atom%n(j,icell)*atom%lines(kc)%gij)
+                   write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") &
+                        100 * atom%n(i,icell) / ntotal_atom(icell,atom), 100 * atom%n(j,icell) / ntotal_atom(icell,atom)
+                   write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") &
+                        100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), &
+                        100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
+                   write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") &
+                        100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
+                   write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") &
+                        100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
                 elseif (verbose_mode == 1) then
                    if ((wj/wi * atom%n(i,icell) - atom%n(j, icell)*atom%lines(kc)%gij) <= 0 ) then
                       call warning("Background line, population inversion!")
                       write(*,"('at cell '(1I9), ' for atom '(1A2), ' line: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
                       write(*,"(' lambda0='(1F12.5)' nm')") atom%lines(kc)%lambda0
                       write(*,"('w(i)='(1ES20.7E3), '; w(j)='(1ES20.7E3))") wi, wj
-                      write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") atom%n(i,icell), atom%n(j,icell), atom%lines(kc)%gij
-                      write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") atom%nstar(i,icell), atom%nstar(j,icell)
+                      write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") &
+                           atom%n(i,icell), atom%n(j,icell), atom%lines(kc)%gij
+                      write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") &
+                           atom%nstar(i,icell), atom%nstar(j,icell)
                       !           						write(*,*) atom%n(i,icell), wi*atom%n(j, icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))!atom%continua(kc)%gij(la, icell)
-                      write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %;',' (n(i)-n(j)gij)/n(j)gij='(1ES20.7E3)' %')") 100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/atom%n(i,icell), 100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/(atom%n(j,icell)*atom%lines(kc)%gij)
-                      write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") 100 * atom%n(i,icell) / ntotal_atom(icell,atom), 100 * atom%n(j,icell) / ntotal_atom(icell,atom)
-                      write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") 100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), 100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
-                      write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") 100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
-                      write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") 100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
+                      write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %;',' (n(i)-n(j)gij)/n(j)gij='(1ES20.7E3)' %')")&
+                           100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/atom%n(i,icell), &
+                           100 * (wj/wi * atom%n(i,icell)-atom%n(j,icell)*atom%lines(kc)%gij)/(atom%n(j,icell)*atom%lines(kc)%gij)
+                      write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") &
+                           100 * atom%n(i,icell) / ntotal_atom(icell,atom),&
+                           100 * atom%n(j,icell) / ntotal_atom(icell,atom)
+                      write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") &
+                           100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), &
+                           100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
+                      write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") &
+                           100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
+                      write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") &
+                           100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
 
                    endif
                 elseif (verbose_mode == 3) then
                    if ((wj/wi * atom%n(i,icell) - atom%n(j, icell)*atom%lines(kc)%gij) <= 0 ) then
                       call warning("Background line, population inversion!")
                       write(*,"(' => at cell '(1I9), ' for atom '(1A2), ' line: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
-                      write(*,"('  -- n(i)/N='(1ES20.9E3)' m^-3;',' n(j)/N='(1ES20.7E3)' m^-3;', ' gij='(1ES20.9E3))") atom%n(i,icell)/ntotal_atom(icell,atom), atom%n(j,icell)/ntotal_atom(icell,atom), atom%lines(kc)%gij
+                      write(*,"('  -- n(i)/N='(1ES20.9E3)' m^-3;',' n(j)/N='(1ES20.7E3)' m^-3;', ' gij='(1ES20.9E3))") &
+                           atom%n(i,icell)/ntotal_atom(icell,atom), atom%n(j,icell)/ntotal_atom(icell,atom), atom%lines(kc)%gij
                    endif
                 endif
              endif
@@ -473,7 +502,8 @@ contains
 
                    do la=1, atom%continua(kc)%Nr-atom%continua(kc)%Nb+1
                       atom%continua(kc)%alpha_nu(la,icell_d) = atom%continua(kc)%alpha_nu(la,icell_d) * &
-                           D_i(icell_d, neff, real(atom%stage(i)), 1.0, lambda(atom%continua(kc)%Nb+la-1), atom%continua(kc)%lambda0, chi_ion)
+                           D_i(icell_d, neff, real(atom%stage(i)), 1.0, lambda(atom%continua(kc)%Nb+la-1),&
+                           atom%continua(kc)%lambda0, chi_ion)
                    enddo
                 endif
              endif
@@ -503,17 +533,28 @@ contains
                    if (atom%n(i,icell) - atom%n(j,icell) * gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)) <=0 ) then
                       call Warning("Background continuum, population inversion !")
                    endif
-                   write(*,"('at cell '(1I9), ' for atom '(1A2), ' cont: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
-                   write(*,"(' lambda0='(1F12.5)' nm;', ' lambda='(1F12.5)' nm')") atom%continua(kc)%lambda0, lambda_cont(Nblue+la-1)
+                   write(*,"('at cell '(1I9), ' for atom '(1A2), ' cont: '(1I3)' ->'(1I3) ) ") &
+                        icell, atom%ID, i, j
+                   write(*,"(' lambda0='(1F12.5)' nm;', ' lambda='(1F12.5)' nm')") &
+                        atom%continua(kc)%lambda0, lambda_cont(Nblue+la-1)
                    write(*,"('w(i)='(1ES20.7E3), '; w(j)='(1ES20.7E3))") wi, wj
-                   write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") atom%n(i,icell), atom%n(j,icell), gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
-                   write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") atom%nstar(i,icell), atom%nstar(j,icell)
+                   write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") &
+                        atom%n(i,icell), atom%n(j,icell), gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
+                   write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") &
+                        atom%nstar(i,icell), atom%nstar(j,icell)
                    !           						write(*,*) atom%n(i,icell), wi*atom%n(j, icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))!atom%continua(kc)%gij(la, icell)
-                   write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %')") 100 * (atom%n(i,icell)-wi*atom%n(j,icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)))/atom%n(i,icell)
-                   write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") 100 * atom%n(i,icell) / ntotal_atom(icell,atom), 100 * atom%n(j,icell) / ntotal_atom(icell,atom)
-                   write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") 100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), 100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
-                   write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") 100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
-                   write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") 100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
+                   write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %')") &
+                        100 * (atom%n(i,icell)-wi*atom%n(j,icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)))/atom%n(i,icell)
+                   write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") &
+                        100 * atom%n(i,icell) / ntotal_atom(icell,atom), &
+                        100 * atom%n(j,icell) / ntotal_atom(icell,atom)
+                   write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") &
+                        100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), &
+                        100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
+                   write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") &
+                        100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
+                   write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") &
+                        100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
                    !exit
                    !enddo
                 elseif( verbose_mode==1 ) then
@@ -523,16 +564,27 @@ contains
                          call Warning("Background continuum, population inversion !")
 
                          write(*,"('at cell '(1I9), ' for atom '(1A2), ' cont: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
-                         write(*,"(' lambda0='(1F12.5)' nm;', ' lambda='(1F12.5)' nm')") atom%continua(kc)%lambda0, lambda_cont(Nblue+la-1)
+                         write(*,"(' lambda0='(1F12.5)' nm;', ' lambda='(1F12.5)' nm')") &
+                              atom%continua(kc)%lambda0, lambda_cont(Nblue+la-1)
                          write(*,"('w(i)='(1ES20.7E3), '; w(j)='(1ES20.7E3))") wi, wj
-                         write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") atom%n(i,icell), atom%n(j,icell), gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
-                         write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") atom%nstar(i,icell), atom%nstar(j,icell)
+                         write(*,"('n(i)='(1ES20.7E3)' m^-3;',' n(j)='(1ES20.7E3)' m^-3;', ' gij='(1ES20.7E3))") &
+                              atom%n(i,icell), atom%n(j,icell), gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
+                         write(*,"('nstar(i)='(1ES20.7E3)' m^-3;',' nstar(j)='(1ES20.7E3)' m^-3')") &
+                              atom%nstar(i,icell), atom%nstar(j,icell)
                          !           						write(*,*) atom%n(i,icell), wi*atom%n(j, icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))!atom%continua(kc)%gij(la, icell)
-                         write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %')") 100 * (atom%n(i,icell)-wi*atom%n(j,icell)*gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)))/atom%n(i,icell)
-                         write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") 100 * atom%n(i,icell) / ntotal_atom(icell,atom), 100 * atom%n(j,icell) / ntotal_atom(icell,atom)
-                         write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") 100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), 100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
-                         write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") 100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
-                         write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") 100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
+                         write(*,"('(n(i)-n(j)gij)/n(i)='(1ES20.7E3)' %')") &
+                              100 * (atom%n(i,icell)-wi*atom%n(j,icell)*gij * &
+                                     exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)))/atom%n(i,icell)
+                         write(*,"('n(i)/N='(1ES20.7E3)' %;', ' n(j)/N='(1ES20.7E3)' %')") &
+                              100 * atom%n(i,icell) / ntotal_atom(icell,atom),&
+                              100 * atom%n(j,icell) / ntotal_atom(icell,atom)
+                         write(*,"('nstar(i)/N='(1ES20.7E3)' %;', ' nstar(j)/N='(1ES20.7E3)' %')") &
+                              100 * atom%nstar(i,icell) / ntotal_atom(icell,atom), &
+                              100 * atom%nstar(j,icell) / ntotal_atom(icell,atom)
+                         write(*,"('n(i)/ne='(1ES20.7E3)' %;', ' n(i)/ne < prec ='(1L1))") &
+                              100 * atom%n(i,icell) / ne(icell), ( atom%n(i,icell) / ne(icell) < frac_ne_limit)
+                         write(*,"('n(j)/ne='(1ES20.7E3)' %;', ' n(j)/ne < prec ='(1L1))") &
+                              100 * atom%n(j,icell) / ne(icell), ( atom%n(j,icell) / ne(icell) < frac_ne_limit)
                          exit
                       endif
                    enddo
@@ -542,7 +594,10 @@ contains
                       if (atom%n(i,icell) - atom%n(j,icell) * gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell)) <=0 ) then
                          call Warning("Background continuum, population inversion !")
                          write(*,"(' => at cell '(1I9), ' for atom '(1A2), ' cont: '(1I3)' ->'(1I3) ) ") icell, atom%ID, i, j
-                         write(*,"('  -- n(i)/N='(1ES20.9E3)' m^-3;',' n(j)/N='(1ES20.7E3)' m^-3;', ' gij='(1ES20.9E3))") atom%n(i,icell)/ntotal_atom(icell,atom), atom%n(j,icell)/ntotal_atom(icell,atom), gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
+                         write(*,"('  -- n(i)/N='(1ES20.9E3)' m^-3;',' n(j)/N='(1ES20.7E3)' m^-3;', ' gij='(1ES20.9E3))") &
+                              atom%n(i,icell)/ntotal_atom(icell,atom), &
+                              atom%n(j,icell)/ntotal_atom(icell,atom), &
+                              gij * exp(-hc_k/lambda_cont(Nblue+la-1)/T(icell))
                          exit
                       endif
                    enddo
@@ -1082,12 +1137,12 @@ contains
 
           phi0(1:Nlam) = profile(aatom%lines(kc),icell,iterate,Nlam,lambda(Nblue:Nred), x,y,z,x1,y1,z1,u,v,w,l)
 
-
           ! 				if ((aatom%n(i,icell)*wj/wi - aatom%n(j,icell)*aatom%lines(kc)%gij) > 0.0_dp) then
 
 
           chi(Nblue:Nred,id) = chi(Nblue:Nred,id) + &
-               hc_fourPI * aatom%lines(kc)%Bij * phi0(1:Nlam) * (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
+               hc_fourPI * aatom%lines(kc)%Bij * phi0(1:Nlam) * &
+               (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
 
           eta(Nblue:Nred,id)= eta(Nblue:Nred,id) + &
                hc_fourPI * aatom%lines(kc)%Aji * phi0(1:Nlam) * aatom%n(j,icell)
@@ -1233,17 +1288,18 @@ contains
              ! 					if (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell) >= 0.0_dp) then
 
              chi_down(Nb+dk_min-1+la,j,nact,id) = chi_down(Nb+dk_min-1+la,j,nact,id) + &
-                  wl * aatom%lines(kc)%Bij * aatom%lines(kc)%phi_loc(la,iray,id) * (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
+                  wl * aatom%lines(kc)%Bij * aatom%lines(kc)%phi_loc(la,iray,id) &
+                     * (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
 
              chi_up(Nb+dk_min-1+la,i,nact,id) = chi_up(Nb+dk_min-1+la,i,nact,id) + &
-                  wl * aatom%lines(kc)%Bij * aatom%lines(kc)%phi_loc(la,iray,id) * (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
+                  wl * aatom%lines(kc)%Bij * aatom%lines(kc)%phi_loc(la,iray,id) &
+                     * (aatom%n(i,icell)*wj/wi - aatom%lines(kc)%gij*aatom%n(j,icell))
 
 
              ! 					endif
 
              eta_atoms(Nb+dk_min-1+la,nact,id) = eta_atoms(Nb+dk_min-1+la,nact,id) + &
                   hc_fourPI * aatom%lines(kc)%Aji * aatom%lines(kc)%phi_loc(la,iray,id) * aatom%n(j,icell)
-
 
              wphi = wphi + wl * aatom%lines(kc)%phi_loc(la,iray,id)
           enddo freq2_loop

--- a/src/Atoms/profiles.f90
+++ b/src/Atoms/profiles.f90
@@ -23,20 +23,20 @@ MODULE PROFILES
 	integer, parameter :: NbspaceMax = 1
 
 	CONTAINS
-	
+
 	function gradv (icell, x,y,z,x1,y1,z1,u,v,w,l,dk)
 		real(kind=dp) :: gradv, v0, v1
 		real(kind=dp), intent(in) :: x,y,z,x1,y1,z1,u,v,w,l
 		integer, intent(in) :: icell
 		integer, intent(out) :: dk
-		
+
 		dk = 0
 		v0 = v_proj(icell,x,y,z,u,v,w)
 		v1 = v_proj(icell,x1,y1,z1,u,v,w)
 		gradv = (v1-v0)/l
 
 		dk = int(1e-3 * max(v1,v0) / hv + 0.5)
-	
+
 	return
 	end function gradv
 
@@ -53,8 +53,8 @@ MODULE PROFILES
 !                                 				               			l !physical length of the cell
 ! 		type (AtomicLine), intent(in)								:: line
 ! 		real(kind=dp), intent(out) 									:: prof
-! 		
-! 		
+!
+!
 ! 		if (line%voigt) then
 ! 			prof = local_profile_v(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 ! 		elseif (line%pvoigt) then
@@ -64,14 +64,14 @@ MODULE PROFILES
 ! 		else!only gauss
 ! 			prof = local_profile_v(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 ! 		endif
-! 			
+!
 ! 	return
-! 	end subroutine line_profile 
+! 	end subroutine line_profile
 
  	!Might be better because for all lines of an atom or even for all lines of all atoms should be equivalent
 	!if projection done before, we do not need x,y,z,l ect
- 
- 
+
+
 	function local_profile_v(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 		! phi = Voigt / sqrt(pi) / vbroad(icell)
 		integer, intent(in) 							            :: icell, N
@@ -88,7 +88,7 @@ MODULE PROFILES
 		type (AtomicLine), intent(in)								:: line
 		integer														:: Nred, Nblue, i, j, nv
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, local_profile_v
- 
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -96,13 +96,13 @@ MODULE PROFILES
 
 		local_profile_v = 0d0
 		u1(:) = ( (lambda - line%lambda0)/line%lambda0 ) * ( clight/line%atom%vbroad(icell) )
-		
+
 		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
 			omegav(1) = v0
 			Nvspace = 1
 		else
-		
+
 			Omegav = 0d0
 			omegav(1) = v0
 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
@@ -123,32 +123,32 @@ MODULE PROFILES
 		!!if (lsubstract_avg) omegav_mean = sum(omegav(1:Nvspace))/real(Nvspace,kind=dp)
 
 		norm = Nvspace * line%atom%vbroad(icell) * sqrtpi
-		
+
         if (line%voigt) then
 
 			do nv=1, Nvspace
- 
+
 				u1p(:) = u1(:) - (omegav(nv) - omegav_mean)/line%atom%vbroad(icell)
-         
+
 				local_profile_v(:) = local_profile_v(:) + Voigt(N, line%a(icell), u1p)
 			enddo
-			
+
 		else
 			do nv=1, Nvspace
-			
+
 				u1p(:) = u1(:) - (omegav(nv) - omegav_mean)/line%atom%vbroad(icell)
 
 				local_profile_v(:) = local_profile_v(:) + exp(-u1p**2)
-				
+
 			enddo
 		endif
-			
+
 
 		local_profile_v(:) = local_profile_v(:) / norm
 
 	return
 	end function local_profile_v
- 
+
  	!gaussian are NOT interpolated (because it is not much faster but would be costly in memory to store all gaussian lines)
 	function local_profile_interp(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 		! phi = Voigt / sqrt(pi) / vbroad(icell)
@@ -165,7 +165,7 @@ MODULE PROFILES
 		integer														::  Nred, Nblue, i, j, nv, la, j0, i0
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, local_profile_interp!, locprof
 		real(kind=dp), dimension(size(line%u))						:: u0
- 
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -176,23 +176,23 @@ MODULE PROFILES
 
 		local_profile_interp = 0d0
 		u1(:) = (lambda - line%lambda0)/line%lambda0 * clight/vbroad
-		
-			
+
+
 		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
 			omegav(1) = v0 / vbroad
 			Nvspace = 1
 ! 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
-! 			dv = abs(v1-v0)			
+! 			dv = abs(v1-v0)
 ! 			Nvspace = min(max(2,nint(dv/vbroad*20.)),NvspaceMax)
-! 			
+!
 ! 			do nv=2, Nvspace
-! 			
+!
 ! 				omegav(nv) = omegav(nv-1) + (v1 - v0) / real(Nvspace - 1) / vbroad
-! 			
+!
 ! 			enddo
 		else
-		
+
 			Omegav = 0.0_dp
 			omegav(1) = v0 / vbroad
 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
@@ -208,7 +208,7 @@ MODULE PROFILES
 				omegav(nv) = v_proj(icell,xphi,yphi,zphi,u,v,w) / vbroad
 			enddo
 			omegav(Nvspace) = v1 / vbroad
-					
+
 		endif
 
 
@@ -216,19 +216,19 @@ MODULE PROFILES
 !  						write(*,*) v0
 ! 						open(unit=32, file="profile.txt",status="unknown")
 ! 						do la=1, size(line%u)
-! 						
+!
 ! 							write(32,*) line%u(la), line%phi(la,icell)
-! 							
+!
 ! 						enddo
 ! 						close(32)
-! 
+!
 ! 					endif
 
 		if (line%voigt) then
 			u0 = line%u / vbroad
 !  						locprof = 0
 			do nv=1, Nvspace
- 
+
 				u1p(:) = u1(:) - omegav(nv)
 
 				!+ linear_1D_sorted(size(line%u),line%u/vbroad,line%phi(:,icell),N,u1p)
@@ -240,35 +240,35 @@ MODULE PROFILES
 ! 			u0 = line%u / vbroad
 			u0 = line%atom%ug(:) / vbroad
 			do nv=1, Nvspace
- 
+
 				u1p(:) = u1(:) - omegav(nv)
 
 !               	local_profile_interp(:) = local_profile_interp(:) + exp(-u1p*u1p) / sqrtpi / vbroad
  				local_profile_interp(:) = local_profile_interp(:) + linear_1D_sorted(size(line%atom%ug),u0,line%atom%gauss_prof(:,icell),N,u1p)
-             	
-              	
-			enddo		
-		endif 
- 
+
+
+			enddo
+		endif
+
 		local_profile_interp(:) = local_profile_interp(:) / Nvspace
 
 
 !  					if (i==2 .and. j==3 .and. icell==n_cells .and. abs(v0) > 45d3) then
-! 
+!
 ! ! 						open(unit=32, file="profile_t.txt",status="unknown")
 ! ! 						do la=1, N
-! ! 						
+! !
 ! ! 							write(32,*) vbroad*u1(la), locprof(la)
-! ! 							
+! !
 ! ! 						enddo
 ! ! 						close(32)
-! 
+!
 !  						write(*,*) line%a(icell), vbroad
 ! 						open(unit=32, file="profile_i.txt",status="unknown")
 ! 						do la=1, N
-! 						
+!
 ! 							write(32,*) vbroad*u1(la), local_profile_interp(la), u1p(la)
-! 							
+!
 ! 						enddo
 ! 						close(32)
 ! 						stop
@@ -276,7 +276,7 @@ MODULE PROFILES
 
 	return
 	end function local_profile_interp
- 
+
 	function local_profile_thomson(line,icell,lsubstract_avg, N, lambda, x,y,z,x1,y1,z1,u,v,w,l)
 		! phi = Voigt / sqrt(pi) / vbroad(icell)
 		integer, intent(in) 							            :: icell, N
@@ -291,7 +291,7 @@ MODULE PROFILES
 		type (AtomicLine), intent(in)								:: line
 		integer														::  Nred, Nblue, i, j, nv
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, local_profile_thomson
- 
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -301,8 +301,8 @@ MODULE PROFILES
 
 		local_profile_thomson = 0d0
 		u1(:) = (lambda - line%lambda0)/line%lambda0 * clight
-	
-		v0 = v_proj(icell,x,y,z,u,v,w)	
+
+		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
 			omegav(1) = v0
 		else
@@ -312,7 +312,7 @@ MODULE PROFILES
 
 			dv = abs(v1-v0)
 			Nvspace = min(max(2,nint(dv/vbroad*20.)),NvspaceMax)
-		
+
 			do nv=2, Nvspace-1
       			delta_vol_phi = (real(nv,kind=dp))/(real(Nvspace,kind=dp)) * l
 				xphi=x+delta_vol_phi*u
@@ -323,49 +323,49 @@ MODULE PROFILES
 			omegav(Nvspace) = v1
 		endif
 
-		
+
         if (line%voigt) then
 
           	!to do optimize:
           	!Can store them on the grid instead ! but it is fast to evaluate ?
-		
+
 			aL = line%a(icell) * vbroad !(m/s), adamp in doppler units
-		
+
 			aeff = (vbroad**5. + 2.69269*vbroad**4. * aL + 2.42843*vbroad**3. * aL**2. + &
 					4.47163*vbroad**2. *aL**3. + 0.07842*vbroad*aL**4. + aL**5.)**(0.2)
-          		
-          	
+
+
 			ratio = aL/aeff
 			eta = 1.36603*ratio - 0.47719*(ratio*ratio) + 0.11116*(ratio*ratio*ratio)
-			
+
 			do nv=1, Nvspace
- 
-				u1p(:) = ( u1(:) - omegav(nv) ) 
-         
+
+				u1p(:) = ( u1(:) - omegav(nv) )
+
 				local_profile_thomson(:) = local_profile_thomson(:) + &
 					eta * ( aeff/pi * (u1p(:)**2 + aeff**2)**(-1.0) ) + &
 					(1.0_dp - eta) * exp(-(u1p(:)/aeff)**2) / aeff / sqrtpi
-					
+
 			enddo
 
 			local_profile_thomson(:) = local_profile_thomson(:) / Nvspace
-			
+
 		else !pure Gauss, no approximation
 			do nv=1, Nvspace
-			
+
 				u1p(:) = ( u1(:) - omegav(nv) ) / vbroad
 
 				local_profile_thomson(:) = local_profile_thomson(:) + exp(-u1p**2)
-				
+
 			enddo
 			local_profile_thomson(:) = local_profile_thomson(:) / Nvspace /sqrtpi / vbroad
 
 		endif
- 
+
 
 	return
 	end function local_profile_thomson
-	
+
 	function local_profile_dirac(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 		! phi = Voigt / sqrt(pi) / vbroad(icell)
 		integer, intent(in) 							            :: icell, N
@@ -380,7 +380,7 @@ MODULE PROFILES
 		type (AtomicLine), intent(in)								:: line
 		integer														::  Nred, Nblue, i, j, nv, la, j0, i0
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, local_profile_dirac
- 
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -389,14 +389,14 @@ MODULE PROFILES
 
 		local_profile_dirac = 0d0
 		u1(:) = (lambda - line%lambda0)/line%lambda0 * clight/vbroad
-	
+
 		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
-			omegav(1) = v0 / vbroad	
+			omegav(1) = v0 / vbroad
 			Nvspace = 1
 		else
 			Omegav = 0.0
-			omegav(1) = v0 / vbroad	
+			omegav(1) = v0 / vbroad
 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
 			dv = abs(v1-v0)
 			Nvspace = min(max(2,nint(dv/vbroad*20.)),NvspaceMax)
@@ -413,20 +413,20 @@ MODULE PROFILES
 
 
 		do nv=1, Nvspace
- 
+
 			u1p(:) = u1(:) - omegav(nv)
 
 
 			local_profile_dirac(:) = local_profile_dirac(:) + dirac_line(N, u1p)
 		enddo
 
- 
+
 		local_profile_dirac(:) = local_profile_dirac(:) / Nvspace / vbroad / sqrtpi
 
 
 	return
 	end function local_profile_dirac
-	
+
 	function local_profile_gate(line,icell,lsubstract_avg,N,lambda, x,y,z,x1,y1,z1,u,v,w,l)
 		! phi = Voigt / sqrt(pi) / vbroad(icell)
 		integer, intent(in) 							            :: icell, N
@@ -441,7 +441,7 @@ MODULE PROFILES
 		type (AtomicLine), intent(in)								:: line
 		integer														::  Nred, Nblue, i, j, nv, la, j0, i0
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, local_profile_gate
- 
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -451,12 +451,12 @@ MODULE PROFILES
 		local_profile_gate = 0d0
 		u1(:) = (lambda - line%lambda0)/line%lambda0 * clight/vbroad
 		max_u = (lambda(Nred) - line%lambda0) / line%lambda0 * clight / vbroad
-	
+
 		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
 			omegav(1) = v0 / vbroad
 			Nvspace = 1
-		else	
+		else
 			Omegav = 0d0
 			omegav(1) = v0 / vbroad
 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
@@ -475,14 +475,14 @@ MODULE PROFILES
 
 
 		do nv=1, Nvspace
- 
+
 			u1p(:) = u1(:) - omegav(nv)
 
 
 			local_profile_gate(:) = local_profile_gate(:) + gate_line(N, u1p, max_u)
 		enddo
 
- 
+
 		local_profile_gate(:) = local_profile_gate(:) / Nvspace / vbroad / sqrtpi
 
 
@@ -507,19 +507,19 @@ MODULE PROFILES
 		type (AtomicLine), intent(in)								:: line
 		integer														:: i1, i2, i, j, nv, dk_mean, dk(NvspaceMax)
 		real(kind=dp), dimension(N)			                    	:: local_profile_dk
- 
+
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
 		i1 = locate(lambda, line%lambdamin)
 		i2 = locate(lambda, line%lambdamax)
 
 		local_profile_dk = 0d0
-		
+
 		dk = 0
 		v0 = v_proj(icell,x,y,z,u,v,w)
-		
+
 		if (lvoronoi) then
-			dk(1) = int(1e-3 * v0/hv + 0.5)		
+			dk(1) = int(1e-3 * v0/hv + 0.5)
 			Nvspace = 1
 		else
 			dk(1) = int(1e-3 * v0/hv + 0.5)
@@ -547,17 +547,17 @@ MODULE PROFILES
 
 	return
 	end function local_profile_dk
-	
-	
+
+
 ! 	function local_zprofile_vd !voigt + dispersion profiles
-! 	
+!
 ! 	return
 ! 	end function local_zprofile_vd
-! 	
+!
 ! 	function local_zprofile_thomson
 ! 	return
 ! 	end function local_zprofile_thomson
-! 	
+!
 ! 	function local_zprofile_interp
 ! 	return
 ! 	end function local_zprofile_interp
@@ -584,23 +584,23 @@ MODULE PROFILES
 		real(kind=dp), dimension(N)			                    	:: u1, u1p, ub
 		real(kind=dp), intent(out)									:: phi0(N), phiZ(N,3), psiZ(N,3)
 		real(kind=dp)												:: H(N), F(N), psi(N,-1:1), phi(N,-1:1)
- 
+
  		B = B_project_angles(icell,x,y,z,u,v,w,cog,sigsq,c2c,s2c)
- 				
+
 ! 		write(*,*) B*1e4, cog, sigsq, c2c, s2c
 ! 		stop
 
 		!those correspond to I, Q, U, V with phi0 for I and psiZ(:,i) for i=Q,U,V
 		phi0(:) = 0.0
 		phiz(:,:) = 0.0; psiz(:,:) = 0.0
-				
+
 		!psi and phi are the Zeeman components with -1, 0 and +1 depending on the deltaM
 
 		if ((B < tiny_dp).or..not.(line%polarizable)) then
 			phi0 = local_profile_v(line,icell,lsubstract_avg,N,lambda,x,y,z,x1,y1,z1,u,v,w,l)
 			return
 		endif
-		
+
 
 		Nvspace = NvspaceMax
 		i = line%i; j = line%j
@@ -610,14 +610,14 @@ MODULE PROFILES
 
 		u1(:) = ( (lambda - line%lambda0)/line%lambda0 ) * ( clight/vbroad )
 
-		v0 = v_proj(icell,x,y,z,u,v,w)		
+		v0 = v_proj(icell,x,y,z,u,v,w)
 		if (lvoronoi) then
 			omegav(1) = v0
 			Nvspace = 1
 		else
 			Omegav = 0d0
 			omegav(1) = v0
-		
+
 			v1 = v_proj(icell,x1,y1,z1,u,v,w)
 
 			dv = abs(v1-v0)
@@ -637,46 +637,46 @@ MODULE PROFILES
 
 		norm = Nvspace * vbroad * sqrtpi
 		psi = 0.0_dp; phi = 0.0_dp
-		
+
         if (line%voigt) then
 
 			do nv=1, Nvspace
-				 
+
 				u1p(:) = u1(:) - (omegav(nv) - omegav_mean)/vbroad
-         
+
           		do nc=1,Nzc
              ! the splitting is 0 if unpolarized 'cause zm%shift(nc=Nzc=1)=0d0
              !there is a + omegaB because, -deltaLam^JJp_MMp=splitting = lamB * (gp*Mp - g*M)
              		ub = u1p(:) + line%zm%shift(nc) * B * LARMOR * line%lambda0 * NM_TO_M / vbroad
-             		
+
              		H = Voigt(line%Nlambda, line%adamp, ub, F)
 
              		psi(:,line%zm%q(nc)) = psi(:,line%zm%q(nc)) + line%zm%strength(nc) * F(:) / norm
-              			
+
              		phi(:,line%zm%q(nc)) = phi(:,line%zm%q(nc)) + line%zm%strength(nc) * H(:) / norm
-          		end do !components         
-         
+          		end do !components
+
 			enddo
-			
+
 		else
 			do nv=1, Nvspace
-			
+
 				u1p(:) = u1(:) - (omegav(nv) - omegav_mean)/vbroad
 
           		do nc=1,Nzc
              ! the splitting is 0 if unpolarized 'cause zm%shift(nc=Nzc=1)=0d0
              !there is a + omegaB because, -deltaLam^JJp_MMp=splitting = lamB * (gp*Mp - g*M)
              		ub = u1p(:) + line%zm%shift(nc) * B * LARMOR * line%lambda0 * NM_TO_M / vbroad
-             		
+
              		H = exp(-ub**2)
              		F = -2 * ub(:) * H !?
 !-> need a version for a = 0 that returns gaussian + dispersion profile with a = 0
-!              		H = Voigt(line%Nlambda, 0.0_dp, ub, F)      
-             		
+!              		H = Voigt(line%Nlambda, 0.0_dp, ub, F)
+
              		psi(:,line%zm%q(nc)) = psi(:,line%zm%q(nc)) + line%zm%strength(nc) * F(:) / norm
-              			
+
              		phi(:,line%zm%q(nc)) = phi(:,line%zm%q(nc)) + line%zm%strength(nc) * H(:) / norm
-          		end do !components 
+          		end do !components
 
 			enddo
 		endif
@@ -689,14 +689,14 @@ MODULE PROFILES
         phiZ(:,2) = 0.5*(phi(:,0)-0.5*(phi(:,-1)+phi(:,1)))*s2c*sigsq
     !chiV/chiI
         phiZ(:,3) = 0.5*(phi(:,-1)-phi(:,1))*cog
-        
+
     !rhoQ/chiI
-        psiz(:,1) = 0.5*(psi(:,0)-0.5*(psi(:,-1)+psi(:,1)))*c2c*sigsq	
+        psiz(:,1) = 0.5*(psi(:,0)-0.5*(psi(:,-1)+psi(:,1)))*c2c*sigsq
     !rhoU/chiI
         psiz(:,2) = 0.5*(psi(:,0)-0.5*(psi(:,-1)+psi(:,1)))*s2c*sigsq
     !rhoV/chiI
         psiz(:,3) = 0.5*(psi(:,-1)-psi(:,1))*cog
-        
+
 !         if (line%i==1 .and. line%j==3) then
 !         	write(*,*) maxval(abs(psiz(:,1))), maxval(abs(psiz(:,2))), maxval(abs(psiz(:,3)))
 !         	write(*,*) minval(abs(psiz(:,1))), minval(abs(psiz(:,2))), minval(abs(psiz(:,3)))
@@ -704,19 +704,19 @@ MODULE PROFILES
 !         write(*,*) "phiI =", phi0(N/2)
 !         write(*,*) "chiQ=", phiz(N/2,1), " chiU=", phiz(N/2,2), " chiV=", phiz(N/2,3)
 !         write(*,*) "rQ=", psiz(N/2,1), " rU=", psiz(N/2,2), " rV=", psiz(N/2,3)
-!         
+!
 !         write(*,*) "phiI =", phi0(1)
 !         write(*,*) "chiQ=", phiz(1,1), " chiU=", phiz(1,2), " chiV=", phiz(1,3)
 !         write(*,*) "rQ=", psiz(1,1), " rU=", psiz(1,2), " rV=", psiz(1,3)
-!         
+!
 !         write(*,*) "phiI =", phi0(N)
 !         write(*,*) "chiQ=", phiz(N,1), " chiU=", phiz(N,2), " chiV=", phiz(N,3)
-!         write(*,*) "rQ=", psiz(N,1), " rU=", psiz(N,2), " rV=", psiz(N,3)	
+!         write(*,*) "rQ=", psiz(N,1), " rU=", psiz(N,2), " rV=", psiz(N,3)
 
 	return
 	end subroutine local_profile_zv
 
- 
+
  SUBROUTINE write_profile(unit, icell, line, kc, wphi)
  	integer, intent(in) :: unit, icell, kc
  	type (AtomicLine), intent(in) :: line
@@ -726,17 +726,18 @@ MODULE PROFILES
  	!damp not computed, to much time ?
  	write(unit, *) " icell = ", icell, " atom = ", line%atom%ID, " vbroad = ", line%atom%vbroad(icell)
  	write(unit, *) " l0 = ", line%lambda0, " lmin = ", line%lambdamin, " lmax = ", line%lambdamax
- 	write(unit, *) " resol (nm) = ", lambda(line%Nblue+1)-lambda(line%Nblue), " resol(km/s) = ",1d-3 * clight*(lambda(line%Nblue+1)-lambda(line%Nblue))/lambda(line%Nblue)
+ 	write(unit, *) " resol (nm) = ", lambda(line%Nblue+1)-lambda(line%Nblue),&
+                  " resol(km/s) = ",1d-3 * clight*(lambda(line%Nblue+1)-lambda(line%Nblue))/lambda(line%Nblue)
  	if (allocated(line%a)) then
  		write(unit, *) " Area = ", wphi," damping = ", line%a(icell)
  	else
   		write(unit, *) " Area = ", wphi
 	endif
  	!!write(unit,*) " Vd (km/s) = ", 1e-3*line%atom%vbroad(icell),  " a = ", damp
- 
+
  RETURN
- END SUBROUTINE 
- 
+ END SUBROUTINE
+
 !  SUBROUTINE write_profiles_ascii(unit, atom, delta_k)
 !	use atmos, only : ....
 !   type(AtomType), intent(in) :: atom
@@ -744,10 +745,10 @@ MODULE PROFILES
 !   integer, intent(in), optional :: delta_k
 !   integer :: dk, kr, l, la, icell, Np
 !   type(AtomType), pointer :: HH
-!   
+!
 !   write(*,*)  " Writing profiles for atom ", atom%ID
 !   HH => atmos%Atoms(1)%ptr_atom
-!   
+!
 !   if (present(delta_k)) then
 !    dk = delta_k
 !    if (dk <= 0 .or. dk > atmos%Nspace) then
@@ -757,13 +758,13 @@ MODULE PROFILES
 !   else
 !    dk = 1
 !   endif
-!   
+!
 !   Np = n_cells
 !   Np = int((n_cells-1)/dk + 1)
 !   if (Np /= n_cells) then
 !    write(*,*) " Effective number of depth points written:", Np, n_cells
 !   endif
-!   
+!
 !   open(unit, file=trim(atom%ID)//"_profiles.txt", status="unknown")
 !   write(unit,*) Np, atom%Nline
 !   do icell=1, n_cells, dk
@@ -780,9 +781,9 @@ MODULE PROFILES
 !      enddo
 !    endif
 !   enddo
-! 
+!
 !   close(unit)
-!  
+!
 !  RETURN
 !  END SUBROUTINE write_profiles_ascii
 

--- a/src/Atoms/read_pluto.f90
+++ b/src/Atoms/read_pluto.f90
@@ -15,16 +15,16 @@ module pluto_mod
 	use atmos_type, only : alloc_atomic_atmos, alloc_magnetic_field, wght_per_H, nHtot, ne, &
 							v_char, lmagnetized, vturb, T, icompute_atomRT, calc_ne, laccretion_shock, &
 							Taccretion, write_atmos_domain
-	
+
 	use utils
 	use Voronoi_grid, only : Voronoi, volume, neighbours_list
 	use sph2mcfost, only : SPH_to_Voronoi
 ! 	use grid,
-  
+
 	implicit none
 
 	contains
-  
+
 
 	subroutine setup_mhd_to_mcfost()
 	!here lmhd_voronoi ist true even with model ascii !
@@ -35,7 +35,7 @@ module pluto_mod
 		real(kind=dp), allocatable, dimension(:)	:: rho, hydro_grainsizes
 		real(kind=dp), allocatable, dimension(:,:)	:: rhodust, massdust
 		logical, allocatable, dimension(:)			:: mask
-		
+
 		real(kind=dp)								:: thetai, thetao, tilt
 		integer, parameter							:: Nheader = 3 !Add more, for ascii file
 		character(len=MAX_LENGTH)					:: rotation_law
@@ -54,31 +54,31 @@ module pluto_mod
 		!stores pluto's model name. But also the filename from phantom.. So to date, the two
 		!codes cannot be merged.
 		!This is to be able to use read previous tesselation
-		
-		
+
+
 		lfix_star = .true.
 		lphantom_file = .false.
 		lignore_dust = .true.
 		lrandomize_voronoi = .false.
 		check_previous_tesselation = (.not.lrandomize_voronoi)
-		
+
 		if (lignore_dust) then
 			ndusttypes = 0
 			if (allocated(rhodust)) deallocate(rhodust,massdust)
-			
+
 		else
 			call error("Dust not handled yet for pluto models!")
 		endif
-		
+
 		!lvoronoi = .true. -> set to .true. if lmhd_voronoi
 		lmagnetized = lzeeman_polarisation !if Zeeman polarisation read magnetic field!
-		if (lmagnetized) then 
+		if (lmagnetized) then
 			call warning("Magnetic field not read yet with Voronoi grid. lzeeman_polarisation set to .false.!")
 			lzeeman_polarisation = .false.
 			lmagnetized = .false.
 			!!call alloc_magnetic_field()
 		endif
-		
+
 		if (lpluto_file) then
 			write(*,*) "Voronoi tesselation on Pluto model..."
 			!read and convert to mcfost units
@@ -86,8 +86,8 @@ module pluto_mod
 		elseif (lmodel_ascii) then
 			!read density_file
 			!Reading ascii file in the same format as atmos_type.f90 / readAtmos_ascii()
-			!but I intend to deprecate readAtmos_ascii.	
-			
+			!but I intend to deprecate readAtmos_ascii.
+
 			cmd = "wc -l "//trim(density_file)//" > ntest.txt"
 			call appel_syst(cmd,syst_status)
 			open(unit=1,file="ntest.txt",status="old")
@@ -111,13 +111,13 @@ module pluto_mod
 			!unused her, but still present
 			call getnextline(1, "#", FormatLine, inputline, Nread)
 			read(inputline(1:Nread),*) thetai, thetao, tilt
-			
+
    			allocate(h(n_points), stat=alloc_status)
    			if (alloc_status > 0) then
    				call error("Allocation error smoothing length h")
    			endif
 			!cut cells larger than 3*h
-			
+
 			allocate(particle_id(n_points), stat=alloc_status)
 			if (alloc_status > 0) then
 				call error("Allocation error particle_id (mhd_to_mcfost)")
@@ -134,13 +134,14 @@ module pluto_mod
    			if (alloc_status > 0) then
    				call error("Allocation error vx, vy, vz")
    			endif
-   			
-      		allocate(T_tmp(n_points), vt_tmp(n_points), dz(n_points), mass_gas(n_points), mass_ne_on_massgas(n_points), stat=alloc_status)
+
+      		allocate(T_tmp(n_points), vt_tmp(n_points), dz(n_points), &
+                     mass_gas(n_points), mass_ne_on_massgas(n_points), stat=alloc_status)
    			if (alloc_status > 0) then
    				call error("Allocation error T_tmp")
    			endif
-   
-			icell = 0	
+
+			icell = 0
 			Nread = 0
 			do icell=1, n_points
 				particle_id(icell) = icell
@@ -148,11 +149,13 @@ module pluto_mod
 					call error("Magnetic field not available with Voronoi!")
 				else
 					call getnextLine(1, "#", FormatLine, inputline, Nread)
-					read(inputline(1:Nread),*) x(icell), y(icell), z(icell), T_tmp(icell), mass_gas(icell), mass_ne_on_massgas(icell), vx(icell), vy(icell), vz(icell), vt_tmp(icell), dz(icell)
+					read(inputline(1:Nread),*) x(icell), y(icell), z(icell), &
+                    T_tmp(icell), mass_gas(icell), mass_ne_on_massgas(icell), &
+                    vx(icell), vy(icell), vz(icell), vt_tmp(icell), dz(icell)
 				endif
 			enddo
 			!density_file
-			
+
 			h(:) = maxval(sqrt(x**2+y**2+z**2))
 
 		else
@@ -191,13 +194,15 @@ module pluto_mod
 !     	ndusttypes = 1 !oterwise bug
 !     	allocate(massdust(1, n_points),rhodust(1, n_points),hydro_grainsizes(1))
     	!** bug handling
-		call sph_to_voronoi(n_points, ndusttypes, particle_id, x, y, z, h, vx, vy, vz, mass_gas, massdust, rho, rhodust, hydro_grainsizes, hydro_limits, check_previous_tesselation)
+		call sph_to_voronoi(n_points, ndusttypes, particle_id, x, y, z, h, &
+                          vx, vy, vz, mass_gas, massdust, rho, rhodust, &
+                          hydro_grainsizes, hydro_limits, check_previous_tesselation)
     	! -> correction for small density applied on mass_gas directly inside
-    	
+
     	!** bug handling
 !     	deallocate(massdust,rhodust,hydro_grainsizes)
     	!** bug handling
-    	
+
 		!*******************************
 		! Accomodating model
 		!*******************************
@@ -219,25 +224,25 @@ module pluto_mod
 			voroindex = Voronoi(icell)%id
 			if (voroindex > 0) then
 				nHtot(icell)  = Msun_to_kg * rho_to_nH * mass_gas(voroindex) /  (volume(icell) * AU3_to_m3)
-				
+
 				!store the ratio of mass electron on mass hydrogen
 				!to do the tesselation only on gas particle
 				!-> if ne is not present in the model, it is simply 0.
 				ne(icell) = Msun_to_kg * mass_ne_on_massgas(voroindex) * mass_gas(voroindex) / (volume(icell) * AU3_to_m3)
-				
+
 				T(icell) = T_tmp(voroindex)
-				
+
 				vturb(icell) = vt_tmp(voroindex)
 
             	icompute_atomRT(icell) = dz(voroindex)
-            	
+
             	vxmax = max(vxmax, abs(Voronoi(icell)%vxyz(1)))
             	vxmin = min(vxmin, max(abs(Voronoi(icell)%vxyz(1)),0.0))
             	vymax = max(vymax, abs(Voronoi(icell)%vxyz(2)))
             	vymin = min(vymin,  max(abs(Voronoi(icell)%vxyz(2)),0.0))
             	vzmax = max(vzmax, abs(Voronoi(icell)%vxyz(3)))
             	vzmin = min(vzmin,  max(abs(Voronoi(icell)%vxyz(3)),0.0))
-            	
+
             	Vmax = max( vmax, sqrt(Voronoi(icell)%vxyz(1)**2 + Voronoi(icell)%vxyz(2)**2 + Voronoi(icell)%vxyz(3)**2) )
 			endif
 		end do
@@ -255,7 +260,7 @@ module pluto_mod
 
 
 ! 		if (lmagnetized) then
-! 		
+!
 ! 		endif
 
 
@@ -264,18 +269,19 @@ module pluto_mod
 		!check that in filled cells there is electron density otherwise we need to compute it
 		!from scratch.
 			if (icompute_atomRT(icell) > 0) then
-   	
+
 				if (ne(icell) <= 0.0_dp) then
 					write(*,*) "  ** No electron density found in the model! ** "
-					calc_ne = .true. 
+					calc_ne = .true.
 					exit icell_loop
 				endif
-   	
-			endif   
+
+			endif
 		enddo icell_loop
 		N_fixed_ne = size(pack(icompute_atomRT,mask=(icompute_atomRT==2)))
 		if (N_fixed_ne > 0) then
-			write(*,'("Found "(1I5)" cells with fixed electron density values! ("(1I3)" %)")') N_fixed_ne, nint(real(N_fixed_ne) / real(n_cells) * 100)
+			write(*,'("Found "(1I5)" cells with fixed electron density values! ("(1I3)" %)")') &
+            N_fixed_ne, nint(real(N_fixed_ne) / real(n_cells) * 100)
 		endif
 
 		call write_atmos_domain() !but for consistency with the plot functions in python
@@ -287,10 +293,10 @@ module pluto_mod
 		write(*,*) "|Vz|", vzmax*1d-3, vzmin*1d-3
 
 
-   
+
 		write(*,*) "Typical line extent due to V fields (km/s):"
 		write(*,*) v_char/1d3
-   
+
 		write(*,*) "Maximum/minimum turbulent velocity (km/s):"
 		write(*,*) maxval(vturb)/1d3, minval(vturb, mask=icompute_atomRT>0)/1d3
 
@@ -302,18 +308,18 @@ module pluto_mod
 		if (.not.calc_ne) then
 			write(*,*) "Maximum/minimum ne density in the model (m^-3):"
 			write(*,*) MAXVAL(ne), MINVAL(ne,mask=icompute_atomRT>0)
-		endif		
+		endif
 
 
 		return
-	end subroutine setup_mhd_to_mcfost 
+	end subroutine setup_mhd_to_mcfost
 
 
 	subroutine read_pluto()
 	!read pluto format in hdf5
-	
+
 		call error("Pluto interface not available yet!")
-	
+
 	return
 	end subroutine read_pluto
 

--- a/src/Atoms/readatom.f90
+++ b/src/Atoms/readatom.f90
@@ -610,7 +610,8 @@ MODULE readatom
 !        atom%continua(kr)%lambdamin = 0.05 * atom%continua(kr)%lambda0
 !        atom%continua(kr)%lambdamin = max(10.0_dp, 1d-2 * atom%continua(kr)%lambda0)
        !!tmp
-       write(*,'(" Continuum "(1I3)" -> "(1I3)" at "(1F12.5)" nm")') atom%continua(kr)%i, atom%continua(kr)%j, atom%continua(kr)%lambda0
+       write(*,'(" Continuum "(1I3)" -> "(1I3)" at "(1F12.5)" nm")') &
+          atom%continua(kr)%i, atom%continua(kr)%j, atom%continua(kr)%lambda0
        write(*,'(" -> lower edge cut at "(1F12.5)" nm !")'), atom%continua(kr)%lambdamin
 
        if (atom%continua(kr)%lambdamin>=atom%continua(kr)%lambda0) then
@@ -1197,7 +1198,8 @@ MODULE readatom
  	do n=1, NactiveAtoms
 
  		if (activeatoms(n)%ptr_atom%cswitch > 1.0) then
- 			activeatoms(n)%ptr_atom%cswitch = max(1.0_dp, min(activeatoms(n)%ptr_atom%cswitch, activeatoms(n)%ptr_atom%cswitch/cswitch_down_scaling_factor))
+ 			activeatoms(n)%ptr_atom%cswitch = max(1.0_dp, &
+            min(activeatoms(n)%ptr_atom%cswitch,activeatoms(n)%ptr_atom%cswitch/cswitch_down_scaling_factor))
  			if (.not. print_message) then
  				print_message = .true.
  				new_cs = activeatoms(n)%ptr_atom%cswitch

--- a/src/Atoms/solvene.f90
+++ b/src/Atoms/solvene.f90
@@ -5,7 +5,7 @@
 ! elements and their abundance and their LTE or NLTE populations.
 !
 !
-! If ne_intial_slution is "NEMODEL" then first guess is computed using 
+! If ne_intial_slution is "NEMODEL" then first guess is computed using
 ! the value stored in ne as first guess.
 ! This allows to iterate the electron density through the NLTE scheme.
 !
@@ -39,31 +39,31 @@ MODULE solvene
  integer, parameter :: N_MAX_ELEMENT=26 !100 is the max, corresponding the atomic number
  real(kind=dp), parameter :: ne_min_limit = 1d-100!if ne < ne_min_limt, ne = 0
  real(kind=dp), parameter :: T_lim_non_lte = 5000.0_dp
- 
+
  integer :: Max_ionisation_stage
  real(kind=dp) :: min_f_HII, max_f_HII
- 
+
  !Introducing a lock for ne iterations with icompute_atomRT == 2
  !the transfer (and opacity) is solved for icompute_atomRT > 0
  !but if icompute_atomRT==2 electron density has the init value.
  !then electron iterations skipped for icompute_atomRT /= 1
 
- 
+
  CONTAINS
 
  function get_max_nstage()
  	integer :: get_max_nstage
  	integer :: ell
- 	
+
  	get_max_nstage = 0
  	do ell=1, Nelem
- 	
+
  		get_max_nstage = max(get_max_nstage, elements(ell)%ptr_elem%Nstage)
- 		
+
  	enddo
- 	
+
  	write(*,*) " Maximum number of ionisation stages among all elements: ", get_max_nstage
- 
+
  return
  end function get_max_nstage
 
@@ -113,7 +113,7 @@ MODULE solvene
   real(kind=dp), intent(in) :: U0, U1
   real(kind=dp) :: phiH
   real(kind=dp), intent(out) :: ne
-  
+
   phiH = phi_jl(k, U0, U1, Elements(1)%ptr_elem%ionpot(1))
 
   !if no free e-, Nt = NH + NH+ with NH+=ne
@@ -141,13 +141,13 @@ MODULE solvene
 
   phiM = phi_jl(k, U0, U1, chi)
   alphaM = A ! relative to H, for instance 1.-6 etc
-  
+
   if (phiM > 0) then
    ne = (sqrt(alphaM*nHtot(k)*phiM +0.25*(1+alphaM)**2) - 0.5*(1+alphaM) ) / phiM
   else
    ne = 0d0
   endif
-  
+
  RETURN
  END SUBROUTINE ne_Metal
 
@@ -157,11 +157,11 @@ MODULE solvene
 !   ! Interpolate the partition function of Element elem in ionisation stage
 !   ! stage at cell point k.
 !  ! ----------------------------------------------------------------------!
-! 
+!
 !   type(Element) :: elem
 !   integer, intent(in) :: stage, k
 !   real(kind=dp) :: Uk, part_func(Npf)
-!   
+!
 !   part_func = elem%pf(stage,:)
 !   Uk = Interp1D(Tpf,part_func,T(k))
 !   !!Uk = (10.d0)**(Uk) !! 29/12/2019 changed log10 in log
@@ -175,7 +175,7 @@ subroutine show_electron_given_per_elem(id, k, max_fjk)
 	real(kind=dp), intent(in), dimension(-N_negative_ions:N_MAX_ELEMENT) :: max_fjk
 	integer :: ell
 	integer, dimension(-N_negative_ions:9) :: list_elem!only six elements
-	
+
 	list_elem(1) = 1 !H
 	list_elem(2) = 2 !He
 	list_elem(3) = 3 !Li
@@ -185,29 +185,29 @@ subroutine show_electron_given_per_elem(id, k, max_fjk)
 	list_elem(7) = 13 !Al
 	list_elem(8) = 19 !K
 	list_elem(9) = 20 !Ca
-	
+
 	!locally
 	if (k > 0 .and. k < n_cells + 1) then
 		write(*,*) " -- Electron given for that cell --"
 		write(*,'("  -- cell #"(1I5)," id#"(1I2)" T="(1F14.4)" K, nHtot="(1ES17.8E3)" m-3")') k, id, T(k), nHtot(k)
 	else!for all
-		write(*,*) " -- Max electron given for all cells --"	
+		write(*,*) " -- Max electron given for all cells --"
 	endif
-	
+
 	do ell=-N_negative_ions, 9
-	
+
 		if (ell==0) then
-	
+
 			write(*,'("  >> H- fjk="(1ES17.8E3))') max_fjk(ell)
 			!(1F18.1)" (x10^10)
 		else
-		
+
 			write(*,'("  >> "(1A)" fjk="(1ES17.8E3))') elements(list_elem(ell))%ptr_elem%id, max_fjk(list_elem(ell))
-		
+
 		endif
 	enddo
-		
-		
+
+
 	!not working properly in term of display
 ! 	write(*,'(" Element          :  ", (A,1x),*(A,10x))') "H-", (elements(list_elem(ell))%ptr_elem%id, ell=1,9)!N_max_element)
 ! 	write(*,'(" fjk (x10^10)     :  ", (1F14.1,1x),*(1F14.1,1x))') 1d10*max_fjk(0), (1d10*max_fjk(list_elem(ell)), ell=1,9)!N_max_element)
@@ -242,10 +242,10 @@ subroutine calc_ionisation_frac(elem, k, ne, fjk, dfjk, n0)
 	real(kind=dp) :: Uk, Ukp1, sum1, sum2
 	logical :: detailed_model
 	integer :: j, i, Nstage, min_j
-	
+
 	Nstage = elem%Nstage
 	fjk(:) = 0.0_dp
-	dfjk(:) = 0.0_dp 
+	dfjk(:) = 0.0_dp
 
 	detailed_model = .false.
 
@@ -255,7 +255,7 @@ subroutine calc_ionisation_frac(elem, k, ne, fjk, dfjk, n0)
 		!.true. before the maxval
 		!detailed_model = (maxval(elem%model%n)>0.0).and.(elem%model%active)
 		!-> two much time to test n > 0 for large model
-		!or just nltepops ? for passive atoms ? 
+		!or just nltepops ? for passive atoms ?
 		detailed_model = (elem%model%NLTEpops .and. elem%model%active)
 		!can add condition on active or not, but check bckgr opac and eval of lte pops after
 	endif
@@ -272,23 +272,23 @@ subroutine calc_ionisation_frac(elem, k, ne, fjk, dfjk, n0)
 ! 		n0 = sum(elem%model%n(:,k),mask=elem%model%stage==min_j)
 
 		do i = 1, elem%model%Nlevel
-		
+
 
 			fjk(elem%model%stage(i)+1) = fjk(elem%model%stage(i)+1)+( elem%model%stage(i)*elem%model%n(i,k) )
 			if (elem%model%stage(i) == min_j) n0 = n0 + elem%model%n(i,k)
-			
-			
-		end do  
-		                                     
+
+
+		end do
+
 		fjk(1:Nstage) = fjk(1:Nstage)/nTotal_atom(k, elem%model)
 ! 		n0 = n0 / ntotal_atom(k,elem%model)
 		n0 = 0.0_dp
-		
+
 		if (elem%model%id == "H") then
 			min_f_HII = min(min_f_HII, fjk(2))
 			max_f_HII = max(max_f_HII, fjk(2))
 		endif
-				
+
 	else !no model use LTE
 		!fjk(1) is N(1) / ntot !N(1) = sum_j=1 sum_i=1^N(j) n(i)
 		fjk(1)=1.
@@ -307,25 +307,25 @@ subroutine calc_ionisation_frac(elem, k, ne, fjk, dfjk, n0)
 ! 			endif
 			!-> fjk is zero if ne=0 in Sahaeq
 			dfjk(j) = -(j-1)*fjk(j)/( ne + ne_min_limit)
-    
+
 			sum1 = sum1 + fjk(j)
 			sum2 = sum2 + dfjk(j)
 
 			Uk = Ukp1
 		end do
-		
+
 		fjk(:)=fjk(:)/sum1
 		dfjk(:)=(dfjk(:)-fjk(:)*sum2)/sum1
 
 		n0 = fjk(1)
-		
+
 		!0 for neutrals => j==1 (elements which do not have a detailed model are ordered by neutral to ionised
 		!and fjk is Nj / Ntot
 		do j=1,elem%Nstage
 			fjk(j) = (j-1) * fjk(j)
 			dfjk(j) = (j-1) * dfjk(j)
 		enddo
-		
+
 		if (elem%id == "H") then
 			min_f_HII = min(min_f_HII, fjk(2))
 			max_f_HII = max(max_f_HII, fjk(2))
@@ -345,7 +345,7 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 	! used. If an element has also an atomic model, and if for
 	! this element NLTE populations are known these pops are
 	! used to compute the electron density. Otherwise, LTE is used.
-	! 
+	!
 	! When ne_initial_solution is set to HIONISA, uses
 	! sole hydgrogen ionisation to estimate the initial ne density.
 	! If set to NPROTON or NEMODEL, protons number or density
@@ -379,7 +379,7 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 	ik_max = 0
 
 	epsilon = 0.0
-	
+
 	min_f_HII = 1d50
 	max_f_HII = 0.0_dp
 	max_fjk(:) = 0.0_dp
@@ -401,9 +401,9 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 		if (icompute_atomRT(k) /= 1) cycle  !<=0 transparent or dark
 											!==2 ne locked to model value
 											!==1 compute with RT
-		
-		!! Initial solution for this cell!! 
-		
+
+		!! Initial solution for this cell!!
+
 		!compute that value in any case of the starting solution
 		!Metal
 		Zm = 11
@@ -417,21 +417,21 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 		else if (ne_initial_solution.eq."NE_MODEL") then
 			ne_old = ne(k)
 		else !"H_IONISATION" or unkown
-   
+
 			!Initial solution ionisation of H
 			elem => Elements(1)%ptr_elem
 			Uk = getPartitionFunctionk(elem, 1, k)
 			Ukp1 = getPartitionFunctionk(elem, 2, k)
 			elem => NULL()
 
-			if (Ukp1 /= 1.0_dp) then 
+			if (Ukp1 /= 1.0_dp) then
 				CALL Warning("Partition function of H+ should be 1")
 				write(*,*) Uk, Ukp1
 				stop
 			end if
 			CALL ne_Hionisation (k, Uk, Ukp1, ne_old)
 
-				
+
 			!if Abund << 1. and chiM << chiH then
 			! ne (H+M) = ne(H) + ne(M)
 			ne_old = ne_old + ne_oldM
@@ -439,9 +439,9 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 			!just set to 0 if < 0: crude ?
 ! 			if (ne_oldM < ne_min_limit) ne_oldM = 0d0
 			if (ne_old < ne_min_limit) ne_old = 0.0_dp
-			
+
 		end if
-		
+
 		!Loop starts
 		ne(k) = ne_old
 		ne0 = ne_old
@@ -457,28 +457,28 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 
 				!times stage !!
 				call calc_ionisation_frac(elem, k, ne_old, fjk, dfjk, n0)
-			
+
 
 				if (n.eq.1)  then ! H minus for H
 					!2 = partition function of HI, should be replace by getPartitionFunctionk(elements(1)%ptr_elem, 1, icell)
 					PhiHmin = phi_jl(k, 1d0, 2d0, E_ION_HMIN)
 					! = 1/4 * (h^2/(2PI m_e kT))^3/2 exp(Ediss/kT)
-					
+
 					!in non-LTE Z * fjk is stored in fjk meaning 0 for fjk(1) !neutrals
 					!How to deal with non-LTE populations with negative ions ?
 					!For instance, fjk(1) = 0 for Hydrogen during the non-LTE (stage * sum(n) / Ntot)
 					!but not at LTE.
-					
+
 					!H- must be multiply their by 1 or by sum(hydrogen%n(1:hydrogen%Nlevel-1))/nHtot
 					!! replace fjk(1) by n0, should be the same at LTE
 					!negative contribution to the electron density
 					delta = delta + ne_old*PhiHmin*n0!
 					sum = sum-(n0 + ne_old*dfjk(1))*PhiHmin ! (fjk(1) + ne_old*dfjk(1))
-					
+
 					max_fjk(0) = max(max_fjk(0),ne_old*PhiHmin*n0)
-					
+
 				end if
-				
+
 				!neutrals do not contribute
 				!j-1 = 0 for neutrals
 				!j-1 = 1 for singly ionised ions.
@@ -501,23 +501,23 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 					sum = sum + akj*dfjk(j)
 					max_fjk(n) = max(max_fjk(n), akj*fjk(j))
 				end do
-				
+
 				elem => NULL()
 			end do !loop over elem
 
 
 			ne(k) = ne_old - nHtot(k)*delta / (1.0-nHtot(k)*sum)
-			
+
 ! 			if (ne(k) == 0.0) then
-! 				write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, sum	
+! 				write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, sum
 ! 				call Warning("electron density is 0 setting to metal value")
 ! 				ne(k) = ne_oldM
-! 			endif			
-			
+! 			endif
+
 ! 			dne = abs((ne(k)-ne_old)/ne_old)
 			dne = abs ( 1.0_dp - ne_old / ne(k) )
 			ne_old = ne(k)
-			
+
 ! 			test epsilon en para et pas para!!!
 			!can I do that in parallel ? epsilon is shared
 ! 			compare to the initial solution (the previous solution in non-LTE)
@@ -527,15 +527,15 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 ! 				epsilon = abs((ne(k) - ne0) / ne0)
 				ik_max = k
 			endif
-    
+
 			if (is_nan_infinity(ne(k))>0) then
 				write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, " sum=", sum
 				call error("electron density is nan or inf!")
 			else if (ne(k) < 0.0) then
-				write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, sum	
+				write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, sum
 				call error("Negative electron density!")
 			endif
-			
+
 			niter = niter + 1
 			if (dne <= MAX_ELECTRON_ERROR) then
 				if (ne(k) < ne_min_limit) then
@@ -547,7 +547,8 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 			else if (niter >= N_MAX_ELECTRON_ITERATIONS) then
 				if (dne > 0.0) then !shows the warning only if dne is actually greater than 1
 					CALL Warning("Electron density has not converged for this cell")
-					write(*,*) "icell=",k,"maxIter=",N_MAX_ELECTRON_ITERATIONS,"dne=",dne,"max(err)=", MAX_ELECTRON_ERROR, "ne=",ne(k), "T=",T(k)," nH=",nHtot(k)
+					write(*,*) "icell=",k,"maxIter=",N_MAX_ELECTRON_ITERATIONS,&
+                  "dne=",dne,"max(err)=", MAX_ELECTRON_ERROR, "ne=",ne(k), "T=",T(k)," nH=",nHtot(k)
 					!set articially ne to some value ?
 					if (dne >= 1.0) then
 						ne(k) = ne_oldM !already tested if < ne_min_limit
@@ -556,7 +557,7 @@ subroutine solve_electron_density(ne_initial_solution, verbose, epsilon)
 				end if
 				unconverged_cells(id) = unconverged_cells(id) + 1 !but count each cell for with dne > MAX_ELECTRON_ERROR
 			end if !convergence test
-    
+
 		end do !while loop
 
 	end do !loop over spatial points
@@ -610,7 +611,7 @@ end subroutine solve_electron_density
   		has_nlte_pops = .true.
   	endif
   endif
-  
+
   fjk(:) = 0d0
   dfjk(:) = 0d0
 
@@ -646,7 +647,7 @@ end subroutine solve_electron_density
     fjk(j) = Sahaeq(k,fjk(j-1),Ukp1,Uk,elem%ionpot(j-1),ne)
     !write(*,*) "j=",j," fjk=",fjk(j)
     !write(*,*) fjk(j-1), fjk(j), fjk(j)/(ne+tiny_dp)
-    
+
     !why without this I have nan ???
     if (ne>0) then
     dfjk(j) = -(j-1)*fjk(j)/ne  !-> fjk(j) should be 0 if ne = 0
@@ -655,10 +656,10 @@ end subroutine solve_electron_density
     else
      dfjk(j) = 0d0
     endif
-    
+
     sum1 = sum1 + fjk(j)
     sum2 = sum2 + dfjk(j)
-    
+
     !write(*,*) "j=",j," dfjk=",dfjk(j), "fjk=", fjk(j), sum1, sum2
 
 
@@ -666,7 +667,7 @@ end subroutine solve_electron_density
    end do
    fjk(:)=fjk(:)/sum1
    dfjk(:)=(dfjk(:)-fjk(:)*sum2)/sum1
-   
+
    if (any_nan_infinity_vector(dfjk)>0) then
        write(*,*) "j=",j," dfjk=",dfjk(j), "fjk=", fjk(j), ne, T(k), sum1, sum2
    stop
@@ -683,7 +684,7 @@ end subroutine solve_electron_density
   ! used. If an element has also an atomic model, and if for
   ! this element NLTE populations are known these pops are
   ! used to compute the electron density. Otherwise, LTE is used.
-  ! 
+  !
   ! When ne_initial_solution is set to HIONISA, uses
   ! sole hydgrogen ionisation to estimate the initial ne density.
   ! If set to NPROTON or NEMODEL, protons number or density
@@ -722,7 +723,7 @@ end subroutine solve_electron_density
 
   !np is the number of protons, by default the last level
   !of Hydrogen.
-  
+
   !Note that will raise errors if np is 0d0 because Hydrogen pops are not
   !known. np is known if:
   ! 1) NLTE populations from previous run are read
@@ -750,12 +751,12 @@ write(*,*) "Test Nelem",Nelem
    else if (initial.eq."NE_MODEL") then
     ne_old = ne(k)
    else !"H_IONISATION" or unkown
-   
+
     !Initial solution ionisation of H
     Uk = getPartitionFunctionk(Elements(1)%ptr_elem, 1, k)
     Ukp1 = getPartitionFunctionk(Elements(1)%ptr_elem, 2, k)
 
-    if (Ukp1 /= 1d0) then 
+    if (Ukp1 /= 1d0) then
      CALL Warning("Partition function of H+ should be 1")
      write(*,*) Uk, Ukp1
      stop
@@ -770,7 +771,7 @@ write(*,*) "Test Nelem",Nelem
       ZM = 11 ! Na !trade off between higher A and lower ionpot
     !else
     !  ZM = 26 ! Fe
-    end if    
+    end if
     !add Metal
     Uk = getPartitionFunctionk(Elements(ZM)%ptr_elem, 1, k)
     Ukp1 = getPartitionFunctionk(Elements(ZM)%ptr_elem, 2, k)
@@ -779,7 +780,7 @@ write(*,*) "Test Nelem",Nelem
     !if Abund << 1. and chiM << chiH then
     ! ne (H+M) = ne(H) + ne(M)
     ne_old = ne_old + ne_oldM
-    
+
     !!!!Check here !!!
     !to avoid having very low values, between say tiny_dp and 1e-100
     !just set to 0 if < 0: crude ?
@@ -822,7 +823,7 @@ write(*,*) "Test Nelem",Nelem
           (1.-nHtot(k)*sum)
     dne = dabs((ne(k)-ne_old)/(ne_old+tiny_dp))
     ne_old = ne(k)
-    
+
     if (is_nan_infinity(ne(k))>0) then
     write(*,*) niter, "icell=",k," T=",T(k)," nH=",nHtot(k), &
               "dne = ",dne, " ne=",ne(k), " nedag = ", ne_old, sum
@@ -847,24 +848,24 @@ write(*,*) "Test Nelem",Nelem
       end if
       unconverged_cells(id) = unconverged_cells(id) + 1 !but count each cell for with dne > MAX_ELECTRON_ERROR
     end if !convergence test
-    
+
    end do !while loop
   end do !loop over spatial points
   !$omp end do
   !$omp end parallel
 
   deallocate(fjk, dfjk)
-  
+
   write(*,*) "Maximum/minimum Electron density in the model (m^-3):"
   write(*,*) MAXVAL(ne),MINVAL(ne,mask=icompute_atomRT>0)
-    
+
   !that's because I use the sum as a variable so the function doesn't exist.
   do k=2, nb_proc
    unconverged_cells(1) = unconverged_cells(1) + unconverged_cells(k)
   end do
   if (unconverged_cells(1) > 0) write(*,*) "Found ", unconverged_cells(1)," unconverged cells (%):", &
   													100*real(unconverged_Cells(1))/real(n_cells)
-  
+
  RETURN
  END SUBROUTINE Solve_Electron_Density_old
 

--- a/src/SPH2mcfost.f90
+++ b/src/SPH2mcfost.f90
@@ -99,7 +99,8 @@ contains
 
     ! Voronoi tesselation
     check_previous_tesselation = (.not. lrandomize_Voronoi)
-    call SPH_to_Voronoi(n_SPH, ndusttypes, particle_id, x,y,z,h, vx,vy,vz, massgas,massdust,rho,rhodust,SPH_grainsizes, SPH_limits, check_previous_tesselation, mask=mask)
+    call SPH_to_Voronoi(n_SPH, ndusttypes, particle_id, x,y,z,h, vx,vy,vz, &
+         massgas,massdust,rho,rhodust,SPH_grainsizes, SPH_limits, check_previous_tesselation, mask=mask)
 
     deallocate(x,y,z,h)
     if (allocated(vx)) deallocate(vx,vy,vz)
@@ -225,14 +226,14 @@ contains
        !    N_part lines containing:
        !  - x,y,z: coordinates of each particle in AU
        !  - h: smoothing length of each particle in AU
-       !  - s: grain size of each particle in µm
+       !  - s: grain size of each particle in ï¿½m
        !
        !  Without grain growth: 2 lines containing:
        !  - n_sizes: number of grain sizes
-       !  - (s(i),i=1,n_sizes): grain sizes in µm
+       !  - (s(i),i=1,n_sizes): grain sizes in ï¿½m
        !  OR
        !  With grain growth: 1 line containing:
-       !  - s_min,s_max: smallest and largest grain size in µm
+       !  - s_min,s_max: smallest and largest grain size in ï¿½m
 
        open(unit=1,file="SPH_phantom.txt",status="replace")
        write(1,*) size(x)
@@ -493,7 +494,8 @@ contains
              endif
           enddo
        enddo cell_loop
-       write(*,*) "Density was reduced by", density_factor, "in", n_force_empty, "cells surrounding the model, ie", (1.0*n_force_empty)/n_cells * 100, "% of cells"
+       write(*,*) "Density was reduced by", density_factor, "in", n_force_empty,&
+          "cells surrounding the model, ie", (1.0*n_force_empty)/n_cells * 100, "% of cells"
     endif
 
     write(*,*) 'Total  gas mass in model :',  real(sum(masse_gaz) * g_to_Msun),' Msun'

--- a/src/Voronoi.f90
+++ b/src/Voronoi.f90
@@ -66,11 +66,13 @@ module Voronoi_grid
   integer :: n_walls
 
   interface
-     subroutine voro(n_points, max_neighbours, limits,x,y,z,h, threshold, n_vectors, cutting_vectors, cutting_distance_o_h, icell_start,icell_end, cpu_id, n_cpu, n_points_per_cpu, &
-          n_in, volume, first_neighbours,last_neighbours,n_neighbours,neighbours_list, was_cell_cut, ierr) bind(C, name='voro_C')
+     subroutine voro(n_points, max_neighbours, limits,x,y,z,h, threshold, n_vectors, &
+                     cutting_vectors, cutting_distance_o_h, icell_start,icell_end, cpu_id, n_cpu, n_points_per_cpu, &
+                     n_in, volume, first_neighbours,last_neighbours,n_neighbours,&
+                     neighbours_list, was_cell_cut, ierr) bind(C, name='voro_C')
        use, intrinsic :: iso_c_binding
 
-       integer(c_int), intent(in), value :: n_points, max_neighbours,icell_start,icell_end, cpu_id, n_cpu, n_points_per_cpu, n_vectors
+       integer(c_int), intent(in), value :: n_points,max_neighbours,icell_start,icell_end,cpu_id,n_cpu,n_points_per_cpu,n_vectors
        real(c_double), dimension(6), intent(in) :: limits
        real(c_double), dimension(n_points), intent(in) :: x,y,z,h
        real(c_double), intent(in), value :: threshold, cutting_distance_o_h ! defines at which value we decide to cut the cell, and at how many h the cell will be cut
@@ -205,7 +207,8 @@ module Voronoi_grid
     real(kind=dp), dimension(:), allocatable :: x_tmp, y_tmp, z_tmp, h_tmp
     integer, dimension(:), allocatable :: SPH_id, SPH_original_id
     real :: time, mem
-    integer :: n_in, n_neighbours_tot, ierr, alloc_status, k, j, n, time1, time2, itime, i, icell, istar, n_sublimate, n_missing_cells, n_cells_per_cpu, nb_proc_voro
+    integer :: n_in, n_neighbours_tot, ierr, alloc_status, k, j, n
+    integer :: time1, time2, itime, i, icell, istar, n_sublimate, n_missing_cells, n_cells_per_cpu, nb_proc_voro
     real(kind=dp), dimension(:), allocatable :: V_tmp
     integer, dimension(:), allocatable :: first_neighbours,last_neighbours
     integer, dimension(:), allocatable :: neighbours_list_loc
@@ -226,7 +229,7 @@ module Voronoi_grid
 !     logical :: lrandom
     integer, dimension(:), allocatable :: order,SPH_id2,SPH_original_id2
     real(kind=dp), dimension(:), allocatable :: x_tmp2,y_tmp2,z_tmp2,h_tmp2
-    
+
 !     lrandom = lrandomize_voronoi
 !     if (lrandom) then
 !     	write(*,*) " Randomized particles, lrandom = True"
@@ -442,7 +445,8 @@ module Voronoi_grid
        allocate(V_tmp(n_cells), was_cell_cut_tmp(n_cells), stat=alloc_status)
        if (alloc_status /=0) call error("Allocation error before voro++ call")
 
-       call voro(n_cells,max_neighbours,limits,x_tmp,y_tmp,z_tmp,h_tmp, threshold, PS%n_faces, PS%vectors, PS%cutting_distance_o_h, &
+       call voro(n_cells,max_neighbours,limits,x_tmp,y_tmp,z_tmp,h_tmp, &
+            threshold, PS%n_faces, PS%vectors, PS%cutting_distance_o_h, &
             icell_start-1,icell_end-1, id-1,nb_proc_voro,n_cells_per_cpu, &
             n_in,V_tmp,first_neighbours,last_neighbours,n_neighbours,neighbours_list_loc,was_cell_cut_tmp,ierr) ! icell & id shifted by 1 for C
        if (ierr /= 0) then
@@ -498,7 +502,8 @@ module Voronoi_grid
        deallocate(neighbours_list_loc)
 
        if (check_previous_tesselation) then
-          call save_Voronoi_tesselation(limits, n_in, n_neighbours_tot,first_neighbours,last_neighbours,neighbours_list,was_cell_cut)
+          call save_Voronoi_tesselation(limits, n_in, n_neighbours_tot,first_neighbours,&
+                                        last_neighbours,neighbours_list,was_cell_cut)
        endif
     else !lcompute
        write(*,*) "Reading previous Voronoi tesselation"
@@ -1015,7 +1020,9 @@ module Voronoi_grid
   !     p_r(i,:) = 0.5 * (Voronoi(id_n)%xyz(:) + r_cell(:)) - r(:) ! we can save an operation here
   !  enddo
 
-    num(1:n_neighbours) = n(1,1:n_neighbours) * p_r(1,1:n_neighbours) + n(2,1:n_neighbours) * p_r(2,1:n_neighbours) + n(3,1:n_neighbours) * p_r(3,1:n_neighbours)
+    num(1:n_neighbours) = n(1,1:n_neighbours) * p_r(1,1:n_neighbours) &
+                        + n(2,1:n_neighbours) * p_r(2,1:n_neighbours) &
+                        + n(3,1:n_neighbours) * p_r(3,1:n_neighbours)
     s_tmp(1:n_neighbours) = num(1:n_neighbours)/den(1:n_neighbours)
 
     s = huge(1.0)

--- a/src/density.f90
+++ b/src/density.f90
@@ -745,7 +745,8 @@ subroutine define_dust_density()
               enddo
            else if (rcyl2 < rin2 - z2) then
               do l=dust_pop(pop)%ind_debut,dust_pop(pop)%ind_fin
-                 densite_pouss(l,icell) = nbre_grains(l) * cst_pous(pop) * rsph**(dz%surf)  * exp(-((rsph-dz%rin)**2)/(2.*dz%edge**2))
+                 densite_pouss(l,icell) = nbre_grains(l) * cst_pous(pop) &
+                    * rsph**(dz%surf)  * exp(-((rsph-dz%rin)**2)/(2.*dz%edge**2))
               enddo
            else
               do l=dust_pop(pop)%ind_debut,dust_pop(pop)%ind_fin

--- a/src/init_mcfost.f90
+++ b/src/init_mcfost.f90
@@ -621,7 +621,7 @@ subroutine initialisation_mcfost()
         lforce_diff_approx=.true.
      case("-mol")
         i_arg = i_arg+1
-        lemission_mol=.true. 
+        lemission_mol=.true.
      case("-safe_stop")
         i_arg = i_arg + 1
         lsafe_stop = .true.
@@ -779,7 +779,7 @@ subroutine initialisation_mcfost()
         lmhd_voronoi = .true.
         lVoronoi = .true.
         l3D = .true.
-     case ("-model_pluto")  
+     case ("-model_pluto")
      	i_arg = i_arg + 1
      	lpluto_file = .true.
      	lmodel_ascii = .false.
@@ -788,7 +788,7 @@ subroutine initialisation_mcfost()
         n_pluto_files = 1
         allocate(density_files(n_pluto_files))
         density_files(1) = s
-        i_arg = i_arg + 1  
+        i_arg = i_arg + 1
      case("-model_ascii")
         i_arg = i_arg + 1
         lmodel_ascii = .true.
@@ -1544,7 +1544,8 @@ subroutine initialisation_mcfost()
      endif
   endif
 
-  if ((.not.limg).and.(.not.lsed).and.(.not.ltemp).and.(.not.lemission_mol).and.(.not.lemission_atom).and.(.not.lstop_after_init)) then
+  if ((.not.limg).and.(.not.lsed).and.(.not.ltemp).and.(.not.lemission_mol)&
+      .and.(.not.lemission_atom).and.(.not.lstop_after_init)) then
      write(*,*) "ERROR: Nothing to calculate!"
      write(*,*) "You can: "
      write(*,*) "- use the [-img wavelength] option to calculate an image"
@@ -1657,11 +1658,11 @@ subroutine initialisation_mcfost()
   lonly_nLTE = .false.
   if (lRE_LTE .and. .not.lRE_nLTE .and. .not. lnRE) lonly_LTE = .true.
   if (lRE_nLTE .and. .not.lRE_LTE .and. .not. lnRE) lonly_nLTE = .true.
-  
+
   if (lpluto_file) then
   	if (.not.lmhd_voronoi) call error("Set lmhd_voronoi to .true. (-mhd_voronoi) if lpluto_file!")
   endif
-  
+
   if (lmodel_ascii .and. lpluto_file) then
   	call warning("lmodel_ascii and lpluto_file ! Assuming lmodel_ascii")
   	lpluto_file = .false.
@@ -1824,7 +1825,7 @@ subroutine display_help()
   write(*,*) "		  : -fix_background_opac : (force) keep background opacities constant during non-LTE loop, if iterate_ne."
   write(*,*) "		  : -limit_memory : continuous opacity are interpolated locally"
   write(*,*) "        : -solve_ne : force the calculation of electron density"
-  write(*,*) "        : -iterate_ne_mc : force the calculation of electron density during Monte Carlo steps."  
+  write(*,*) "        : -iterate_ne_mc : force the calculation of electron density during Monte Carlo steps."
   write(*,*) "        : -iterate_ne <Nperiod> : Iterate ne with populations every Nperiod"
   write(*,*) "        : -Ndelay_iterate_ne <Ndelay> : Iterate ne with populations after Ndelay"
   write(*,*) "        : -see_lte : Force rate matrix to be at LTE"

--- a/src/io_prodimo.f90
+++ b/src/io_prodimo.f90
@@ -217,7 +217,7 @@ contains
                 eps_PAH = dust_pop(pop)%frac_mass /disk_zone(i)%gas_to_dust  ! fraction en masse (de gaz) des PAHS
 
                 ! 1.209274 = (mH2*nH2 + mHe * mHe) / (nH2 + nHe) avec nHe/nH2 = 10^-1.125
-                ! abondance en nombre par rapport à H-nuclei + correction pour NC
+                ! abondance en nombre par rapport ï¿½ H-nuclei + correction pour NC
                 fPAH(i) = fPAH(i) + (1.209274/masse_PAH) * eps_PAH/3e-7 * (NC/50.)
                 !write(*,*) i, fPAH(i), real(dust_pop(pop)%frac_mass * disk_zone(i)%diskmass), real(dust_pop(pop)%frac_mass),  real(disk_zone(i)%diskmass)
              endif  ! PAH
@@ -812,8 +812,8 @@ contains
     !  Write the required header keywords.
     call ftphpr(unit,simple,bitpix,naxis,naxes,0,1,extend,status)
 
-    ! tau est sans dimension : [kappa * lvol = density * a² * lvol]
-    ! C_ext = a² microns² -> 1e-8 cm²             \
+    ! tau est sans dimension : [kappa * lvol = density * aï¿½ * lvol]
+    ! C_ext = aï¿½ micronsï¿½ -> 1e-8 cmï¿½             \
     ! density en cm-3                      > reste facteur 149595.0
     ! longueur de vol en AU = 1.5e13 cm   /
     facteur = AU_to_cm * mum_to_cm**2
@@ -1449,7 +1449,8 @@ contains
     ! Check dimensions
     call ftgknj(unit,'NAXIS',1,10,naxes,nfound,status)
     if (nfound /= 3) call error("failed to read the NAXISn keywords of HDU 7")
-    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p))  call error("HDU 7 does not have the right dimensions.")
+    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p)) &
+       call error("HDU 7 does not have the right dimensions.")
     npixels=naxes(1)*naxes(2)*naxes(3)
 
     ! read_image
@@ -1464,7 +1465,8 @@ contains
     ! Check dimensions
     call ftgknj(unit,'NAXIS',1,10,naxes,nfound,status)
     if (nfound /= 3) call error("failed to read the NAXISn keywords of HDU 8")
-    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p)) call error("HDU 8 does not have the right dimensions.")
+    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p)) &
+       call error("HDU 8 does not have the right dimensions.")
     npixels=naxes(1)*naxes(2)*naxes(3)
 
     ! read_image
@@ -1479,7 +1481,8 @@ contains
     ! Check dimensions
     call ftgknj(unit,'NAXIS',1,10,naxes,nfound,status)
     if (nfound /= 3) call error("failed to read the NAXISn keywords of HDU 9")
-    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p)) call error("HDU 9 does not have the right dimensions.")
+    if ((naxes(1) /= n_rad_m2p).or.(naxes(2) /= nz_m2p).or.(naxes(3) /= n_lambda_m2p)) &
+       call error("HDU 9 does not have the right dimensions.")
     npixels=naxes(1)*naxes(2)*naxes(3)
 
     ! read_image
@@ -1796,7 +1799,8 @@ contains
           ! Check dimensions
           call ftgknj(unit,'NAXIS',1,10,naxes,nfound,fits_status)
           if (nfound /= 3) call error("failed to read the NAXISn keywords of HDU 5+")
-          if ((naxes(1) /= lpops%lmax(i)).or.(naxes(2) /= n_rad).or.(naxes(3) /= nz)) call error("HDU 5+ does not have the right dimensions.")
+          if ((naxes(1) /= lpops%lmax(i)).or.(naxes(2) /= n_rad).or.(naxes(3) /= nz)) &
+             call error("HDU 5+ does not have the right dimensions.")
           npixels=naxes(1)*naxes(2)*naxes(3)
 
           allocate(MCpops(lpops%lmax(i),n_rad,nz), stat=alloc_status)

--- a/src/optical_depth.f90
+++ b/src/optical_depth.f90
@@ -18,7 +18,8 @@ module optical_depth
 
   contains
 
-subroutine physical_length(id,lambda,p_lambda,Stokes,icell,xio,yio,zio,u,v,w,flag_star,flag_direct_star,extrin,ltot,flag_sortie,lpacket_alive)
+subroutine physical_length(id,lambda,p_lambda,Stokes,icell,xio,yio,zio,u,v,w,&
+                           flag_star,flag_direct_star,extrin,ltot,flag_sortie,lpacket_alive)
 ! Integration par calcul de la position de l'interface entre cellules
 ! Ne met a jour xio, ... que si le photon ne sort pas de la nebuleuse (flag_sortie=1)
 ! C. Pinte
@@ -205,7 +206,7 @@ subroutine integ_tau(lambda)
   if (.not.lvariable_dust) then
      icell = icell_ref
      if (kappa(icell,lambda) > tiny_real) then
-        write(*,*) " Column density (g/cm²)   = ", real(tau*(masse(icell)/(volume(icell)*AU_to_cm**3))/ &
+        write(*,*) " Column density (g/cmï¿½)   = ", real(tau*(masse(icell)/(volume(icell)*AU_to_cm**3))/ &
              (kappa(icell,lambda)/AU_to_cm))
      endif
   endif
@@ -223,7 +224,7 @@ subroutine integ_tau(lambda)
   if (.not.lvariable_dust) then
      icell = icell_ref
      if (kappa(icell,lambda) > tiny_real) then
-        write(*,*) " Column density (g/cm²)   = ", real(tau*(masse(icell)/(volume(1)*3.347929d39))/ &
+        write(*,*) " Column density (g/cmï¿½)   = ", real(tau*(masse(icell)/(volume(1)*3.347929d39))/ &
              (kappa(icell,lambda)/1.49597870691e13))
      endif
   endif
@@ -236,7 +237,7 @@ end subroutine integ_tau
 
 subroutine optical_length_tot(id,lambda,Stokes,icell,xi,yi,zi,u,v,w,tau_tot_out,lmin,lmax)
 ! Integration par calcul de la position de l'interface entre cellules
-! de l'opacite totale dans une direction donnée
+! de l'opacite totale dans une direction donnï¿½e
 ! Grille a geometrie cylindrique
 ! C. Pinte
 ! 19/04/05
@@ -332,7 +333,8 @@ subroutine compute_column(type, column, lambda)
   column(:,:) = 0.0
   do direction = 1, n_directions
      !$omp parallel default(none) &
-     !$omp shared(densite_gaz,tab_abundance,lVoronoi,Voronoi,direction,column,r_grid,z_grid,phi_grid,n_cells,cross_cell,CD_units,kappa,lambda,type,test_exit_grid) &
+     !$omp shared(densite_gaz,tab_abundance,lVoronoi,Voronoi,direction) &
+     !$omp shared(column,r_grid,z_grid,phi_grid,n_cells,cross_cell,CD_units,kappa,lambda,type,test_exit_grid) &
      !$omp private(icell,previous_cell,next_cell,icell0,x0,y0,z0,x1,y1,z1,norme,u,v,w,l,l_contrib,l_void_before,factor,sum)
      !$omp do
      do icell=1,n_cells
@@ -401,47 +403,47 @@ end subroutine compute_column
 !   ! ------------------------------------------------------------------ !
 !   ! special for atomic line RT.
 !   ! ------------------------------------------------------------------ !
-! 
+!
 !   use metal, only                         : Background, BackgroundLines, BackgroundLines_lambda, Backgroundcontinua
 !   use spectrum_type, only                 : NLTEspec, initAtomOpac
 !   use opacity, only						  : NLTEOpacity!, NLTEOpacity_lambda
-! 
+!
 !   integer, intent(in)                    :: id, lambda, icell
 !   real(kind=dp),dimension(4), intent(in) :: Stokes
 !   real(kind=dp), intent(in)              :: u,v,w
 !   real(kind=dp), intent(in)              :: xi,yi,zi
 !   real, intent(out)                      :: tau_tot_out
 !   real(kind=dp), intent(out)             :: lmin,lmax
-! 
+!
 !   real(kind=dp)                          :: x0, y0, z0, x1, y1, z1, l,   &
 !                                             ltot, tau, opacite, tau_tot, &
 !                                             correct_plus, correct_moins, &
 !                                             l_contrib, l_void_before, kappa_c, &
 !                                             tau_tot_cont
-! 
+!
 !   integer                                :: icell0, previous_cell, next_cell
-! 
+!
 !   correct_plus = 1.0_dp + prec_grille
 !   correct_moins = 1.0_dp - prec_grille
-! 
+!
 !   x1=xi;y1=yi;z1=zi
-! 
+!
 !   tau_tot=0.0_dp
 !   tau_tot_cont=0.0_dp
-! 
+!
 !   lmin=0.0_dp
 !   ltot=0.0_dp
-! 
+!
 !   next_cell = icell
 !   icell0 = 0 ! for previous_cell, just for Voronoi
-! 
+!
 !   ! Boucle infinie sur les cellules
 !   do ! Boucle infinie
 !      ! Indice de la cellule
 !      previous_cell = icell0
 !      icell0 = next_cell
 !      x0=x1;y0=y1;z0=z1
-! 
+!
 !      ! Test sortie
 !      if (test_exit_grid(icell0, x0, y0, z0)) then
 !         tau_tot_out=tau_tot
@@ -449,11 +451,11 @@ end subroutine compute_column
 !         NLTEspec%atmos%tau = tau_tot_cont
 !         return
 !      end if
-! 
+!
 !      ! Calcul longeur de vol et profondeur optique dans la cellule
 !      call cross_cell(x0,y0,z0, u,v,w,  icell0, previous_cell, x1,y1,z1, &
 !           next_cell, l, l_contrib, l_void_before)
-! 
+!
 !      if (icell0<=n_cells) then
 !         if (NLTEspec%Atmos%icompute_atomRT(icell0)>0) then
 !            call initAtomOpac(id) !set opac to zero for this cell and thread.
@@ -481,21 +483,21 @@ end subroutine compute_column
 !         opacite = 0d0 !cell is empty
 !         kappa_c = 0d0
 !      end if !
-! 
+!
 !      tau=l_contrib*opacite ! opacite constante dans la cellule
 !      tau_tot_cont = tau_tot_cont + l_contrib*kappa_c
-! 
+!
 !      tau_tot = tau_tot + tau
 !      ltot= ltot + l
-! 
+!
 !      if (tau_tot < tiny_real) lmin=ltot
-! 
+!
 !   end do ! boucle infinie
-! 
+!
 !   write(*,*) "BUG"
-! 
+!
 !   return
-! 
+!
 ! end subroutine atom_optical_length_tot
 
 !***********************************************************
@@ -1005,7 +1007,7 @@ subroutine define_dark_zone(lambda,p_lambda,tau_max,ldiff_approx)
   do pk=1, n_az
      ri_in_dark_zone(pk)=n_rad
      ri_out_dark_zone(pk)=1
-     ! étape 1 : radialement depuis le centre
+     ! ï¿½tape 1 : radialement depuis le centre
      somme = 0.0
      do1 : do i=1,n_rad
         somme=somme+kappa(cell_map(i,1,pk),lambda)*(r_lim(i)-r_lim(i-1))
@@ -1015,7 +1017,7 @@ subroutine define_dark_zone(lambda,p_lambda,tau_max,ldiff_approx)
         endif
      enddo do1
 
-     ! étape 2 : radialement depuis rout
+     ! ï¿½tape 2 : radialement depuis rout
      somme = 0.0
      do2 : do i=n_rad,1,-1
         somme=somme+kappa(cell_map(i,1,pk),lambda)*(r_lim(i)-r_lim(i-1))
@@ -1027,7 +1029,7 @@ subroutine define_dark_zone(lambda,p_lambda,tau_max,ldiff_approx)
      if (ri_out_dark_zone(pk)==n_rad) ri_out_dark_zone(pk)=n_rad-1
 
      if (lcylindrical) then
-        ! étape 3 : verticalement
+        ! ï¿½tape 3 : verticalement
         do i=ri_in_dark_zone(pk), ri_out_dark_zone(pk)
            somme = 0.0
            do3 : do j=nz, 1, -1
@@ -1039,7 +1041,7 @@ subroutine define_dark_zone(lambda,p_lambda,tau_max,ldiff_approx)
            enddo do3
         enddo
 
-        ! étape 3.5 : verticalement dans autre sens
+        ! ï¿½tape 3.5 : verticalement dans autre sens
         if (l3D) then
            do i=ri_in_dark_zone(pk), ri_out_dark_zone(pk)
               somme = 0.0
@@ -1062,7 +1064,7 @@ subroutine define_dark_zone(lambda,p_lambda,tau_max,ldiff_approx)
   l_is_dark_zone = .false.
   l_dark_zone(:) = .false.
 
-  ! étape 4 : test sur tous les angles
+  ! ï¿½tape 4 : test sur tous les angles
   if (.not.l3D) then
      cell : do i=max(ri_in_dark_zone(1),2), ri_out_dark_zone(1)
         do j=zj_sup_dark_zone(i,1),1,-1

--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -48,7 +48,7 @@ module parametres
 
   integer :: RT_sed_method ! cf routine dust_map pour def
 
-  ! Etapes de l'émission thermique
+  ! Etapes de l'ï¿½mission thermique
   logical :: ltemp, lsed, lsed_complete, l_em_disk_image, lchauff_int, lextra_heating, lno_internal_energy
   character(len=512), dimension(:), allocatable :: indices
   character(len=512) :: tab_wavelength
@@ -62,24 +62,24 @@ module parametres
   				lmagnetoaccr, lforce_lte, lspherical_velocity, lstop_after_jnu, &
        			ldissolve, laccurate_integ, loutput_rates, lorigin_atom, lzeeman_polarisation!lcontrib_function
   integer :: Nrays_atom_transfer, istep_start
-  
+
   !HEALpix
   integer :: healpix_lorder, healpix_lmin, healpix_lmax !lmin and lmax not yet (for local evaluation)
-  
+
   logical :: llimit_mem, lfix_backgrnd_opac
   logical :: lcheckpoint, lsafe_stop
   !Convergence relative errors
   real :: dpops_max_error, dpops_sub_max_error, art_hv, safe_stop_time
   integer :: checkpoint_period
-  
+
   !Ng's acceleration
   logical :: lng_acceleration
   integer :: iNg_Norder, iNg_ndelay, iNg_Nperiod
-  
+
   !electron density
   logical :: lsolve_for_ne, lno_iterate_ne_mc = .true. !.true.==no electron iteration during step 2
   integer :: ndelay_iterate_ne, n_iterate_ne !0 means once SEE is solved. Otherwise, > 1, iterated every n_iterate_ne during the nlte_loop
-  
+
   !Wavelength table for spectrally resolved images and spectra
   character(len=50) :: tab_wavelength_image, jnu_atom_file
   logical :: ltab_wavelength_image, lread_jnu_atom
@@ -98,7 +98,7 @@ module parametres
 
   ! Production d'images symetriques
   ! La symetrie est effectuee avant de choisir les pixels
-  ! le système est-il centrosymetrique
+  ! le systï¿½me est-il centrosymetrique
   ! le systeme a-t-il une symetrie axiale (ne compte que si N_phi > 1)
   logical :: l_sym_ima, l_sym_centrale, l_sym_axiale
 
@@ -108,11 +108,11 @@ module parametres
   real :: angle_interet, zoom, tau_seuil, wl_seuil
 
   real  :: cutoff = 7.0
-  
+
   !must be initialized to 0
   integer(kind=8) :: mem_alloc_tot !total memory allocated dynamically or not in bytes
 
-  ! Résolution de la grille de densité
+  ! Rï¿½solution de la grille de densitï¿½
   ! Nombre de cellules dans la direction r (echantillonage log)
   integer :: grid_type ! 1 = cylindrical, 2 = spherical
   integer :: n_rad, n_rad_in  ! subdivision de la premiere cellule
@@ -127,7 +127,8 @@ module parametres
   logical :: lopacite_only, lseed, ldust_prop, ldisk_struct, loptical_depth_map, lreemission_stats
   logical :: lapprox_diffusion, lcylindrical, lspherical, lVoronoi, is_there_disk, lno_backup, lonly_diff_approx, lforce_diff_approx
   logical :: laverage_grain_size, lisotropic, lno_scattering, lqsca_equal_qabs
-  logical :: ldensity_file, lsigma_file, lvelocity_file, lvfield_cyl_coord, lphantom_file, lphantom_multi, lphantom_avg, lgadget2_file, lascii_SPH_file, llimits_file, lSPH_amin, lSPH_amax, lmcfost_lib
+  logical :: ldensity_file, lsigma_file, lvelocity_file, lvfield_cyl_coord, lphantom_file
+  logical :: lphantom_multi, lphantom_avg, lgadget2_file, lascii_SPH_file, llimits_file, lSPH_amin, lSPH_amax, lmcfost_lib
   logical :: lweight_emission, lcorrect_density, lProDiMo2mcfost, lProDiMo2mcfost_test, lastrochem, lML
   logical :: lspot, lforce_PAH_equilibrium, lforce_PAH_out_equilibrium, lchange_Tmax_PAH, lISM_heating, lcasa
   integer :: ISR_model ! 0 : no ISM radiation field, 1 : ProDiMo, 2 : Bate & Keto
@@ -147,8 +148,10 @@ module parametres
   logical :: lread_grain_size_distrib, lphase_function_file,ltau1_surface, lwrite_column_density, lwrite_mol_column_density
 
   ! Phantom
-  logical :: ldudt_implicit, lscale_length_units, lscale_mass_units, lignore_dust, ldelete_Hill_sphere, lrandomize_Voronoi, lrandomize_azimuth, lrandomize_gap, lrandomize_outside_gap, lcentre_on_sink
-  real(kind=dp) :: ufac_implicit,scale_length_units_factor,scale_mass_units_factor,correct_density_factor_elongated_cells, SPH_amin, SPH_amax, fluffyness, gap_factor
+  logical :: ldudt_implicit, lscale_length_units, lscale_mass_units, lignore_dust
+  logical :: ldelete_Hill_sphere, lrandomize_Voronoi, lrandomize_azimuth, lrandomize_gap, lrandomize_outside_gap, lcentre_on_sink
+  real(kind=dp) :: ufac_implicit,scale_length_units_factor,scale_mass_units_factor
+  real(kind=dp) :: correct_density_factor_elongated_cells, SPH_amin, SPH_amax, fluffyness, gap_factor
   logical :: lupdate_velocities, lno_vr, lno_vz, lvphi_Kep, lfluffy
   integer :: isink_centre
 

--- a/src/read_param.f90
+++ b/src/read_param.f90
@@ -3983,7 +3983,8 @@ end subroutine read_para215
     endif
 
     do i=1,n_etoiles
-       read(1,*) etoile(i)%T, etoile(i)%r, etoile(i)%M, etoile(i)%x, etoile(i)%y, etoile(i)%z, etoile(i)%find_spectrum, etoile(i)%fUV
+       read(1,*) etoile(i)%T, etoile(i)%r, etoile(i)%M, etoile(i)%x, &
+                 etoile(i)%y, etoile(i)%z, etoile(i)%find_spectrum, etoile(i)%fUV
        if (.not.etoile(i)%find_spectrum) then
           read(1,*) etoile(i)%spectre
        else

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -932,13 +932,16 @@ subroutine phantom_2_mcfost(np,nptmass,ntypes,ndusttypes,n_files,dustfluidtype,x
  do i=1,nptmass
     n_etoiles = n_etoiles + 1
     if (real(xyzmh_ptmass(4,i)) * scale_mass_units_factor > 0.013) then
-       write(*,*) "Sink #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * scale_length_units_factor), "au, M=", real(xyzmh_ptmass(4,i) * scale_mass_units_factor), &
+       write(*,*) "Sink #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * scale_length_units_factor),&
+            "au, M=", real(xyzmh_ptmass(4,i) * scale_mass_units_factor), &
             "Msun, Mdot=", real(xyzmh_ptmass(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
     else
-       write(*,*) "Sink #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * scale_length_units_factor), "au, M=", real(xyzmh_ptmass(4,i) * GxMsun/GxMjup * scale_mass_units_factor), &
+       write(*,*) "Sink #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * scale_length_units_factor), &
+            "au, M=",real(xyzmh_ptmass(4,i) * GxMsun/GxMjup * scale_mass_units_factor), &
             "Mjup, Mdot=", real(xyzmh_ptmass(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
     endif
-    if (i>1) write(*,*)  "       distance=", real(norm2(xyzmh_ptmass(1:3,i) - xyzmh_ptmass(1:3,1)) * scale_length_units_factor), "au"
+    if (i>1) write(*,*)  "       distance=", &
+       real(norm2(xyzmh_ptmass(1:3,i) - xyzmh_ptmass(1:3,1)) * scale_length_units_factor), "au"
  enddo
 
 
@@ -972,7 +975,8 @@ subroutine phantom_2_mcfost(np,nptmass,ntypes,ndusttypes,n_files,dustfluidtype,x
           !vphi = - vx(i) * sin_phi + vy(i) * cos_phi
 
           ! Keplerian vphi
-          vphi = sqrt(Ggrav * xyzmh_ptmass(4,1) * scale_mass_units_factor * Msun_to_kg  * (r_cyl * AU_to_m)**2 /  (r_sph * AU_to_m)**3 )
+          vphi = sqrt(Ggrav * xyzmh_ptmass(4,1) * scale_mass_units_factor &
+                 * Msun_to_kg  * (r_cyl * AU_to_m)**2 /  (r_sph * AU_to_m)**3 )
 
           vx(i) = vr * cos_phi - vphi * sin_phi
           vy(i) = vr * sin_phi + vphi * cos_phi

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -51,7 +51,7 @@ function span_dp(xmin,xmax,n, dk)
   real(kind=dp) :: delta_x
 
   delta_x = (xmax-xmin)/real(n-1,kind=dp)
-  
+
   if (dk < 0) then
   	x1 = xmax
   	x2 = xmin
@@ -65,7 +65,7 @@ function span_dp(xmin,xmax,n, dk)
   	iend = n
   	i0 = 1
   endif
-  
+
   span_dp(i0) = x1
   do i=istart,iend,dk
      span_dp(i) = span_dp(i-dk) + dk * delta_x
@@ -331,11 +331,11 @@ end subroutine GaussSlv
 subroutine rotation(xinit,yinit,zinit,u1,v1,w1,xfin,yfin,zfin)
   ! Effectue une rotation du vecteur (xinit,yinit,zinit)
   ! Le resultat (xfin,yfin,zfin) est dans
-  ! le systeme de coordonnees où le vecteur (u1,v1,w1)=(1,0,0).
+  ! le systeme de coordonnees oï¿½ le vecteur (u1,v1,w1)=(1,0,0).
   ! ie applique la meme rotation que celle qui transforme
   ! (1,0,0) en (u1,v1,w1) sur (xinit,yinit,zinit)
   ! C. Pinte : 1/03/06
-  ! Nouvelle version d'une routine de F. Ménard
+  ! Nouvelle version d'une routine de F. Mï¿½nard
 
   implicit none
 
@@ -358,7 +358,7 @@ subroutine rotation(xinit,yinit,zinit,u1,v1,w1,xfin,yfin,zfin)
    !     !c'est pas un atan mais un atan2 d'on le sign(u1)
    !     cost=sign(1.0/sqrt(1.0+x*x),u1)        !cos(atan(x)) = 1/(1+sqrt(x*x))
    !     sint=x*cost                            !sin(atan(x)) = x/(1+sqrt(x*x))
-        ! Equivalent  à  (~ meme tps cpu):
+        ! Equivalent  ï¿½  (~ meme tps cpu):
          theta=atan2(v1,u1)
          cost=cos(theta)
          sint=sin(theta)
@@ -876,7 +876,8 @@ subroutine mcfost_v()
   read(1,*,iostat=ios) last_version
   close(unit=1,status="delete",iostat=ios)
 
-  if ((ios/=0) .or. (.not.is_digit(last_version(1:1)))) call error("Cannot get MCFOST last version number (Error 2)","Cannot read new version file")
+  if ((ios/=0) .or. (.not.is_digit(last_version(1:1)))) &
+     call error("Cannot get MCFOST last version number (Error 2)","Cannot read new version file")
 
   ! Do we have the last version ?
   if (last_version == mcfost_release) then
@@ -1536,7 +1537,7 @@ subroutine cdapres(cospsi, phi, u0, v0, w0, u1, v1, w1)
 !*
 !***************************************************
 ! 06/12/05 : - passage double car bug sous Icare
-!            - reduction nbre d'opérations
+!            - reduction nbre d'opï¿½rations
 !            (C. Pinte)
 !***************************************************
 


### PR DESCRIPTION
I cleaned up a bunch of these while hunting for the seg fault. Seems bad practice to have very long lines in f90 anyway, so thought you might want to clean these up anyhow. 

Up to the seg fault in opacity.f90 now compiles fine without -ffree-line-length-none