### PR TITLE
Reading extra options from .in phantom file

### DIFF
--- a/src/mcfost2phantom.f90
+++ b/src/mcfost2phantom.f90
@@ -5,7 +5,7 @@ module mcfost2phantom
 contains
 
   subroutine init_mcfost_phantom(mcfost_para_filename, ndusttypes, use_SPH_limits_file, SPH_limits_file, SPH_limits, ierr, &
-       keep_particles, fix_star, turn_on_Lacc, turn_on_dust_subl)
+       keep_particles, fix_star, turn_on_Lacc, turn_on_dust_subl, use_ISM_heating)
 
     use parametres
     use init_mcfost, only : set_default_variables, get_mcfost_utils_dir
@@ -26,7 +26,7 @@ contains
     real(dp), dimension(6), intent(out) :: SPH_limits
     integer, intent(out) :: ierr
     real, intent(in), optional :: keep_particles
-    logical, intent(in), optional :: fix_star, turn_on_Lacc, turn_on_dust_subl
+    logical, intent(in), optional :: fix_star, turn_on_Lacc, turn_on_dust_subl, use_ISM_heating
     integer, target :: lambda, lambda0
     integer, pointer, save :: p_lambda
 
@@ -63,6 +63,13 @@ contains
        endif
     endif
 
+    lISM_heating = .false.
+    if (present(use_ISM_heating)) then
+       if (use_ISM_heating) then
+          lISM_heating = .true.
+          write(*,*) "WARNING: ISM heating is turned on"
+       endif
+    endif
     ! Model limits
     if (use_SPH_limits_file) then
        call read_SPH_limits_file(SPH_limits_file, SPH_limits)
@@ -250,7 +257,7 @@ contains
     mu_gas = mu ! Molecular weight
 
     call phantom_2_mcfost(np,nptmass,ntypes,ndusttypes,do_nucleation,n_files,dustfluidtype,xyzh,&
-         vxyzu,T_gas,iphase,grainsize,dustfrac(1:ndusttypes,np),nucleation(:,:),massoftype2(1,1:ntypes),&
+         vxyzu,T_gas,iphase,grainsize,dustfrac(1:ndusttypes,np),nucleation,massoftype2(1,1:ntypes),&
          xyzmh_ptmass,vxyz_ptmass,hfact,umass,utime,udist,graindens,ndudt,dudt,ifiles,&
          n_SPH,x_SPH,y_SPH,z_SPH,h_SPH,vx_SPH,vy_SPH,vz_SPH,Tgas_SPH,particle_id,&
          SPH_grainsizes,massgas,massdust,rhogas,rhodust,extra_heating,ieos)

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -774,7 +774,8 @@ contains
     real(dp), dimension(ndusttypes),    intent(in) :: graindens
     real(dp), dimension(n_files,ntypes), intent(in) :: massoftype
     real(dp), intent(in) :: hfact,umass,utime,ulength
-    real(dp), dimension(:,:), intent(in) :: xyzmh_ptmass, vxyz_ptmass, nucleation
+    real(dp), dimension(:,:), intent(in) :: xyzmh_ptmass, vxyz_ptmass
+    real(dp), dimension(:,:), intent(inout), allocatable :: nucleation
     real(dp), dimension(:), intent(in) :: gastemperature
     integer, intent(in) :: ndudt
     real(dp), dimension(:), intent(in) :: dudt


### PR DESCRIPTION
Added optional argument to be able to set ISM_heating from phantom .in file
Fixed a segmentation fault with nucleation when run with DEBUG=yes

Tested by compiling MCFOST+Phantom