### PR TITLE
Patches for Intel oneAPI (ifx) compatibility

### DIFF
--- a/lib/ifx/config.mk
+++ b/lib/ifx/config.mk
@@ -1,0 +1,36 @@
+# Voro++, a 3D cell-based Voronoi library
+#
+# Author : Chris H. Rycroft (LBL / UC Berkeley)
+# Email  : chr@alum.mit.edu
+# Date   : August 28th 2011
+
+# This a common configuration file that includes definitions used by all
+# the Makefiles.
+
+# C++ compiler
+CXX=icpx
+
+ifeq ($(shell uname | tr '[a-z]' '[A-Z]' 2>&1 | grep -c DARWIN),1)
+     ARCH= -axSSSE3,SSE4.1,SSE4.2,AVX,CORE-AVX2 -mmacosx-version-min=10.12 -mdynamic-no-pic
+else
+     ARCH= -axSSSE3,SSE4.1,SSE4.2,AVX
+endif
+
+# Flags for the C++ compiler
+CFLAGS=-Wall -ansi -pedantic -O3 -fp-model fast=2 -DVOROPP_VERBOSE=1 $(ARCH)
+
+# Relative include and library paths for compilation of the examples
+E_INC=-I../../src
+E_LIB=-L../../src
+
+# Installation directory
+PREFIX=/usr/local
+
+# Install command
+INSTALL=install
+
+# Flags for install command for executable
+IFLAGS_EXEC=-m 0755
+
+# Flags for install command for non-executable files
+IFLAGS=-m 0644

--- a/lib/ifx/make.CHOICES
+++ b/lib/ifx/make.CHOICES
@@ -1,0 +1,77 @@
+############################################################################
+#
+#	Three decisions to make:
+#		1. Platform
+#		2. MPI version or Non-MPI version
+#		3. Is libgmp.a available
+#
+############################################################################
+#---------------------------------------------------------------------------
+#
+#		1. Platform
+#
+# We have set variables giving information on the archiver, the C compiler
+# and the FORTRAN compiler for certain machines in SRC/make.xxx, where xxx
+# is your machine name. In the lines that state: PLAT = ... , exactly one of
+# the lines must not be commented out. This line corresponds to the machine
+# you are on. For example, if you are on a Cray T3E, remove the '#' sign from
+# the beginning of the corresponding line. Change the following line:
+#      #PLAT = T3E		# Cray T3E
+# to:
+#      PLAT = T3E		# Cray T3E
+#
+# If the machine you are on is not in the list, please send mail to:
+# ashoks@ncsa.uiuc.edu stating the machine you are on. You may also modify
+# the make.GENERIC file to suit your machine and continue with the 'make'
+# process.
+#
+#---------------------------------------------------------------------------
+
+#PLAT = CONVEX
+#PLAT = DEC
+#PLAT = HP
+#PLAT = INTEL
+#PLAT = O2K
+#PLAT  = SGI
+#PLAT = SP2		# IBM SP2
+#PLAT = SUN
+# For T3D, Use PLAT=T3E instead
+#PLAT =  T3E
+#PLAT  = GENERIC
+PLAT = INTEL
+
+############################################################################
+
+#---------------------------------------------------------------------------
+#
+#		2. MPI version or Non-MPI version
+#
+#	MPI version: uncomment the following line and
+#		modify appropriate make.(PLAT) file
+#
+#	Non-MPI version: comment out the following line
+#---------------------------------------------------------------------------
+
+#MPIDEF = -DSPRNG_MPI
+
+############################################################################
+
+
+#---------------------------------------------------------------------------
+#		3. Is libgmp.a available
+#
+# comment out if you want to exclude generator pmlcg which needs libgmp
+#---------------------------------------------------------------------------
+
+#PMLCGDEF = -DUSE_PMLCG
+#GMPLIB = -lgmp
+
+############################################################################
+
+
+#---------------------------------------------------------------------------
+#	library dir for libsprng.a
+# By default, the libraries are placed in the sprng/lib directory.
+# You can change this through the variable 'LIB_REL_DIR' below.
+#---------------------------------------------------------------------------
+LIB_REL_DIR = lib

--- a/lib/ifx/make.INTEL
+++ b/lib/ifx/make.INTEL
@@ -1,0 +1,34 @@
+AR = ar
+ARFLAGS = cr
+#If your system has ranlib, then replace next statement with the one after it.
+#RANLIB = echo
+RANLIB = ranlib
+CC = icx -std=gnu90
+CLD = $(CC)
+F77 = ifx -w95
+F77LD = $(F77)
+FFXN =  -DAdd_
+FSUFFIX = F
+
+MPIF77 = $(F77)
+MPICC = $(CC)
+
+# To use MPI, set the MPIDIR to location of mpi library, and MPILIB
+# to name of mpi library. Remove # signs from beginning of next 3 lines.
+# Also, if the previous compilation was without MPI, type: make realclean
+# before compiling for mpi.
+#
+MPIDIR =
+MPILIB =
+
+# If _LONG_LONG type is available, then you can use the addition flag
+# -D_LONG_LONG. Set F77 to echo to compile the C version alone.
+# Try adding: -DGENERIC to CFLAGS. This can improve speed, but may give
+# incorrect values. Check with 'checksprng' to see if it works.
+
+CFLAGS = -O $(PMLCGDEF) $(MPIDEF)  -DPOINTER_SIZE=8
+CLDFLAGS = -O -DPOINTER_SIZE=8 -D_LONG_LONG
+FFLAGS = -O $(PMLCGDEF) $(MPIDEF) -DPOINTER_SIZE=8
+F77LDFLAGS = -O
+
+CPP = f77 -F

--- a/lib/ifx/sprng2.0b.patch
+++ b/lib/ifx/sprng2.0b.patch
@@ -1,0 +1,24 @@
+diff -Naur A/SRC/primes_32.c B/SRC/primes_32.c
+--- A/SRC/primes_32.c	1999-06-29 12:42:11.000000000 -0400
++++ B/SRC/primes_32.c	2023-03-20 17:19:37.000000000 -0400
+@@ -7,7 +7,7 @@
+ #define NO  0
+ #define NPRIMES 1000
+ 
+-int primes[NPRIMES];
++static int primes[NPRIMES];
+ 
+ #ifdef __STDC__
+ int init_prime_32(void)
+diff -Naur A/SRC/primes_64.c B/SRC/primes_64.c
+--- A/SRC/primes_64.c	1999-06-29 12:42:11.000000000 -0400
++++ B/SRC/primes_64.c	2023-03-20 17:19:46.000000000 -0400
+@@ -7,7 +7,7 @@
+ #define NO  0
+ #define NPRIMES 10000
+ 
+-int primes[NPRIMES];
++static int primes[NPRIMES];
+ 
+ #ifdef __STDC__
+ int init_prime_64(void)

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -61,7 +61,7 @@ if [ ! $# = 0 ]; then SYSTEM=$1; fi
 
 set +u # personalized error messages
 if [ -z "$SYSTEM" ]; then
-    echo "error: SYSTEM need to be set (choose: ifort or gfortran)."
+    echo "error: SYSTEM need to be set (choose: ifort, ifx, or gfortran)."
     exit 1
 fi
 if [ -z "$MCFOST_INSTALL" ]; then
@@ -76,6 +76,12 @@ if [ "$SYSTEM" = "ifort" ]; then
     export FC=ifort
     export CXX=icpc
     export CFLAGS=""
+elif [ "$SYSTEM" = "ifx" ]; then
+    echo "Building MCFOST's libraries with ifx"
+    export CC=icx
+    export FC=ifx
+    export CXX=icpx
+    export CFLAGS="-std=gnu90"
 elif [ "$SYSTEM" = "gfortran" ]; then
     echo "Building MCFOST's libraries with gfortran"
     export CC=gcc
@@ -84,7 +90,7 @@ elif [ "$SYSTEM" = "gfortran" ]; then
     export CFLAGS="-m64"
 else
     echo "Unknown system to build MCFOST: $SYSTEM"
-    echo "Please choose ifort or gfortran"
+    echo "Please choose ifort, ifx, or gfortran"
     echo "install.sh <system>"
     echo "Exiting"
     exit 1
@@ -139,6 +145,9 @@ tar xzvf sprng2.0b.tar.gz
 if [ "$SYSTEM" = "gfortran" ] ; then
     \cp -f "$SYSTEM/primes_64.c" sprng2.0/SRC # recent gfortran has an issue with having duplicate symbols between primes_32 and primes_64
 fi
+if [ "$SYSTEM" = "ifx" ]; then
+    patch -p1 -d sprng2.0 < ifx/sprng2.0b.patch
+fi
 if [ "$os" = "macos" ]; then
     \cp -f macos/insertmenu.mac sprng2.0/SRC/insertmenu
 fi
@@ -170,6 +179,8 @@ echo "Done"
 echo "Compiling Voro++ ..."
 if [ "$SYSTEM" = "ifort" ]; then
     \cp -f ifort/config.mk voro
+elif [ "$SYSTEM" = "ifx" ]; then
+    \cp -f ifx/config.mk voro
 elif [ "$SYSTEM" = "gfortran" ]; then
     \cp -f gfortran/config.mk voro
 fi

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,6 +21,10 @@ ifeq ($(ifort), yes)
     SYSTEM=ifort
 endif
 
+ifeq ($(ifx), yes)
+    SYSTEM=ifx
+endif
+
 ifndef OPENMP
     OPENMP=yes
 endif
@@ -100,6 +104,30 @@ ifeq ($(SYSTEM), ifort)
     COMPFLAGS= -fopenmp
     LIBCXX= -cxxlib
     LIBS= $(LIB)/ifort
+endif
+
+ifeq ($(SYSTEM), ifx)
+    ifeq ($(shell uname | tr '[a-z]' '[A-Z]' 2>&1 | grep -c DARWIN),1)
+        ARCH= -axSSSE3,SSE4.1,SSE4.2,AVX,CORE-AVX2 -mmacosx-version-min=10.12 -mdynamic-no-pic
+        STATIC_FLAGS= -static-intel -qopenmp-link static
+    else
+        ARCH= -axSSSE3,SSE4.1,SSE4.2,AVX,CORE-AVX2,CORE-AVX512
+        STATIC_FLAGS= -static-intel -qopenmp-link static -static-libstdc++
+    endif
+    FC= ifx
+    FFLAGS= -fpp -O3 -fp-model fast=2 -traceback $(ARCH)
+    DBLFLAG= -r8
+    DEBUGFLAG= -check all -C -g -fpe0 -traceback -no-ftz \
+               -warn uninitialized -warn unused -warn truncated_source
+    KNOWN_SYSTEM= yes
+    FOMPFLAGS= -qopenmp
+    IPOFLAGS= -ipo
+    CC= icx
+    CXX=icpx -std=c++11
+    CCFLAGS= -O3 -fp-model fast=2 -traceback $(ARCH)
+    COMPFLAGS= -qopenmp
+    LIBCXX= -cxxlib
+    LIBS= $(LIB)/ifx
 endif
 
 ifeq ($(SYSTEM), gfortran)


### PR DESCRIPTION
This commit includes additions that enable a new `SYSTEM` target of `ifx` for the Intel oneAPI toolchain.  Compilers are `icx`/`icpx`/`ifx` with appropriate modifications to the compiler flags.

- The `lib/install.sh` has been modified to allow this new target and to apply a patch to the sprng 2.0b code to make the `primes` arrays in `primes_32.c` and `primes_64.c` static (global scoped to that source file only, eliminates the duplicate symbol error also seen with newer `gfortran` builds).
- The 'src/Makefile' has been modified to include the new target.