### PR TITLE
Adding the possibility to use mueller matrices as input for mcfost.

### DIFF
--- a/src/dust_prop.f90
+++ b/src/dust_prop.f90
@@ -652,6 +652,8 @@ subroutine prop_grains(lambda)
      endif ! is_opacity_file
   enddo !k
 
+  if (loverwrite_s12) call overwrite_s12(Pmax)
+
   ! Verif normalization
   !-- do  k=1,n_grains_tot
   !--    norme = 0.0
@@ -1070,7 +1072,7 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
   !$omp shared(tab_s11,tab_s12,tab_s33,tab_s34,lambda,p_lambda,n_grains_tot,tab_albedo_pos,prob_s11_pos) &
   !$omp shared(zmax,kappa,kappa_abs_LTE,ksca_CDF,p_n_cells,fact) &
   !$omp shared(C_ext,C_sca,densite_pouss,S_grain,scattering_method,tab_g_pos,aniso_method,tab_g,lisotropic,low_mem_scattering) &
-  !$omp shared(lscatt_ray_tracing,letape_th,lsepar_pola,ldust_prop,lphase_function_file,s11_file) &
+  !$omp shared(lscatt_ray_tracing,letape_th,lsepar_pola,ldust_prop,lphase_function_file,s11_file,loverwrite_s12,Pmax) &
   !$omp private(icell,k,density,norme,theta,k_sca_tot,mu,g,g2)
   !$omp do schedule(dynamic,1)
   do icell=1, p_n_cells
@@ -1148,6 +1150,12 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
            ! (for ray-tracing)
            tab_s11_pos(:,icell,p_lambda) = tab_s11_pos(:,icell,p_lambda) * dtheta / (k_sca_tot * deux_pi)
 
+           if (loverwrite_s12) then
+              do l=0,nang_scatt
+                 theta = real(l)*dtheta
+                 tab_s12_o_s11_pos(l,icell,p_lambda) = - Pmax * (1-(cos(theta))**2)
+              enddo
+           endif
 
            ! -- ! aniso_method = 2 --> HG
            ! -- gsca = tab_g_pos(icell,lambda)
@@ -1170,7 +1178,6 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
               tab_s34_o_s11_pos(:,icell,p_lambda)=0.0
            endif
         endif !aniso_method
-
 
         ! todo :
         ! utiliser tab_s11_pos pour raie tracing et tab_s12_o_s11

--- a/src/dust_prop.f90
+++ b/src/dust_prop.f90
@@ -541,10 +541,12 @@ end function Bruggeman_EMT
 !******************************************************************************
 
 subroutine prop_grains(lambda)
-  ! Calcule les propriétés des grains
+  ! Calcule les propriÃ©tÃ©s des grains
   ! Masse, fraction en nombre, sections efficaces, matrices de muellers
   ! sortie des routines opacite
   ! C. Pinte 7/01/05
+  ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+  ! 20/04/2023
 
   !use benchmarks, only : read_Pascucci_cross_sections
 
@@ -566,7 +568,7 @@ subroutine prop_grains(lambda)
   !$omp default(none) &
   !$omp private(k,a,x,qext,qsca,gsca,amu1,amu2,pop) &
   !$omp shared(r_grain,C_ext,C_sca,C_abs,C_abs_norm,wavel,aexp,tab_albedo,lambda,tab_g,grain) &
-  !$omp shared(laggregate,tab_amu1,tab_amu2,n_grains_tot,S_grain) &
+  !$omp shared(laggregate, lmueller, lper_size, tab_amu1,tab_amu2,n_grains_tot,S_grain) &
   !$omp shared(tab_amu1_coating,tab_amu2_coating,amu1_coat,amu2_coat) &
   !$omp shared(dust_pop)
   !$omp do schedule(dynamic,1)
@@ -581,6 +583,15 @@ subroutine prop_grains(lambda)
         x = 2.0 * pi * a / wavel
         if (laggregate) then
            call Mueller_GMM(lambda,k,qext,qsca,gsca)
+        else if (lmueller) then 
+           ! on dÃ©sactive la parallÃ©lisation pour lire le fichier
+           !$omp critical (read)
+           if (lper_size) then
+	      call mueller_input_size(lambda,k,qext,qsca,gsca)
+           else
+	      call mueller_input(lambda,k,qext,qsca,gsca)
+	   endif
+	   !$omp end critical (read)
         else
            if ((dust_pop(pop)%type=="Mie").or.(dust_pop(pop)%type=="mie").or.(dust_pop(pop)%type=="MIE")) then
               if (dust_pop(pop)%lcoating) then
@@ -610,8 +621,8 @@ subroutine prop_grains(lambda)
         C_abs(k,lambda) = C_ext(k,lambda) - C_sca(k,lambda)
 
         ! Normalisation des opacites pour etre en AU^-1 pour fichier thermal_emission.f90
-        ! tau est sans dimension : [kappa * lvol = density * a² * lvol]
-        ! a² microns² -> 1e-8 cm²             \
+        ! tau est sans dimension : [kappa * lvol = density * aÂ² * lvol]
+        ! aÂ² micronsÂ² -> 1e-8 cmÂ²             \
         ! density en cm-3                      > reste facteur AU_to_cm * mum_to_cm**2 = 149595.0
         ! longueur de vol en AU = 1.5e13 cm   /
         C_abs_norm(k,lambda) = C_abs(k,lambda) * AU_to_cm * mum_to_cm**2
@@ -660,6 +671,8 @@ end subroutine prop_grains
 !******************************************************************************
 
 subroutine save_dust_prop(letape_th)
+ ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+ ! 20/04/2023
 
   logical, intent(in) :: letape_th
   character(len=512) :: filename
@@ -671,9 +684,15 @@ subroutine save_dust_prop(letape_th)
   endif
 
   open(1,file=filename,status='replace',form='unformatted')
-  write(1) para_version, scattering_method, dust_pop, grain, &
+  if (lmueller.or.laggregate) then
+     write(1) para_version, scattering_method, dust_pop, grain, .true., &
+       n_lambda, lambda_min, lambda_max, tab_wavelength, &
+       C_ext, C_sca, C_abs, C_abs_norm, tab_g, tab_albedo, prob_s11, tab_mueller
+  else
+     write(1) para_version, scattering_method, dust_pop, grain, .false., &
        n_lambda, lambda_min, lambda_max, tab_wavelength, &
        C_ext, C_sca, C_abs, C_abs_norm, tab_g, tab_albedo, prob_s11, tab_s11, tab_s12, tab_s33, tab_s34
+  endif
   close(unit=1)
 
   return
@@ -683,6 +702,8 @@ end subroutine save_dust_prop
 !******************************************************************************
 
 subroutine read_saved_dust_prop(letape_th, lcompute)
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   logical, intent(in) :: letape_th
   logical, intent(out) :: lcompute
@@ -694,7 +715,7 @@ subroutine read_saved_dust_prop(letape_th, lcompute)
   real :: lambda_min_save, lambda_max_save, para_version_save
 
   integer :: i, pop, ios
-  logical :: ok
+  logical :: ok, lmue
 
   lcompute = .true.
   if (lread_Misselt.or.lread_DustEM) return
@@ -714,13 +735,22 @@ subroutine read_saved_dust_prop(letape_th, lcompute)
   endif
 
   ! read the saved dust properties
-  read(1,iostat=ios) para_version_save, scattering_method_save, dust_pop_save, grain_save, &
+  if (lmueller.or.laggregate) then
+     read(1,iostat=ios) para_version_save, scattering_method_save, dust_pop_save, grain_save, lmue, &
+       n_lambda_save, lambda_min_save, lambda_max_save, tab_wavelength_save, &
+       C_ext, C_sca, C_abs, C_abs_norm, tab_g, tab_albedo, prob_s11, tab_mueller
+     if (.not.lmue) ok = .false.
+  else
+     read(1,iostat=ios) para_version_save, scattering_method_save, dust_pop_save, grain_save, lmue, &
        n_lambda_save, lambda_min_save, lambda_max_save, tab_wavelength_save, &
        C_ext, C_sca, C_abs, C_abs_norm, tab_g, tab_albedo, prob_s11, tab_s11, tab_s12, tab_s33, tab_s34
+     if (lmue) ok = .false.
+  endif
   close(unit=1)
   if (ios /= 0) then ! if some dimension changed
      return
   endif
+  if (.not.ok) return ! To not merge spherical and non-spherical data
 
   ! The parameter version has to be the same for safety
   ! in case something important was modified between 2 versions
@@ -769,6 +799,8 @@ subroutine opacite(lambda, p_lambda, no_scatt)
 ! Doit etre utilise juste apres prop_grain : lambda ne doit pas changer entre 2
 ! (dans le cas multi-longueurs d'onde)
 ! update : 12/09/06
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   implicit none
 
@@ -787,7 +819,7 @@ subroutine opacite(lambda, p_lambda, no_scatt)
   endif
 
   ! Attention : dans le cas no_strat, il ne faut pas que la cellule (1,1,1) soit vide.
-  ! on la met à nbre_grains et on effacera apres
+  ! on la met Ã  nbre_grains et on effacera apres
   ! c'est pour les prop de diffusion en relatif donc la veleur exacte n'a pas d'importante
   ldens0 = .false.
   if (.not.lvariable_dust) then
@@ -907,7 +939,7 @@ subroutine opacite(lambda, p_lambda, no_scatt)
   endif ! letape_th and not onlyLTE
 
 
-  ! proba absorption sur une taille donnée
+  ! proba absorption sur une taille donnÃ©e
   if (lRE_nLTE .and. (.not.low_mem_th_emission_nLTE)) then
      if (letape_th) then
         do icell=1, n_cells
@@ -926,8 +958,8 @@ subroutine opacite(lambda, p_lambda, no_scatt)
   endif !lnLTE
 
   ! Normalisation des opacites kappa_abs pour etre en AU^-1
-  ! tau est sans dimension : [kappa * lvol = density * a² * lvol]
-  ! a² microns² -> 1e-8 cm²             \
+  ! tau est sans dimension : [kappa * lvol = density * aÂ² * lvol]
+  ! aÂ² micronsÂ² -> 1e-8 cmÂ²             \
   ! density en cm-3                      > reste facteur AU_to_cm * mum_to_cm**2 = 149595.0
   ! longueur de vol en AU = 1.5e13 cm   /
   ! fact =  pi * a * a * 149595.0
@@ -952,7 +984,11 @@ subroutine opacite(lambda, p_lambda, no_scatt)
 
   if (compute_scatt) then
      if (scattering_method==2) then
-        call calc_local_scattering_matrices(lambda, p_lambda)
+        if (lmueller) then
+           call calc_local_scattering_matrices_mueller(lambda, p_lambda)
+        else 
+           call calc_local_scattering_matrices(lambda, p_lambda)
+        endif
      else ! scattering_method ==1
         if (.not.low_mem_scattering) then ! we precompute the CDF (otherwise, we recalculate it live)
            do icell=1, p_n_cells
@@ -988,7 +1024,7 @@ subroutine opacite(lambda, p_lambda, no_scatt)
      tab_albedo_pos = 0.5_dp
   endif
 
-  ! On remet la densite à zéro si besoin
+  ! On remet la densite Ã  zÃ©ro si besoin
   if (ldens0) then
      icell = icell_ref
      densite_pouss(:,icell) = 0.0_sp
@@ -1080,7 +1116,7 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
      if (k_sca_tot > tiny_real) then
 
         if (aniso_method==1) then ! full phase function
-           ! Propriétés optiques des cellules
+           ! PropriÃ©tÃ©s optiques des cellules
            prob_s11_pos(0,icell,p_lambda)=0.0
 
            do l=2,nang_scatt ! probabilite de diffusion jusqu'a l'angle j, on saute j=0 car sin(theta) = 0
@@ -1148,7 +1184,7 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
 
      else ! k_sca_tot = 0.0
         tab_albedo_pos(icell,lambda)=0.0
-        ! Propriétés optiques des cellules
+        ! Propri\E9t\E9s optiques des cellules
         prob_s11_pos(:,icell,p_lambda)=1.0
         prob_s11_pos(0,icell,p_lambda)=0.0
         ! Normalisation (idem que dans mueller)
@@ -1167,6 +1203,153 @@ subroutine calc_local_scattering_matrices(lambda, p_lambda)
   return
 
 end subroutine calc_local_scattering_matrices
+
+!******************************************************************************
+
+subroutine calc_local_scattering_matrices_mueller(lambda, p_lambda)
+
+!*************************************************************
+! Routine derivee de calc_local_scattering_matrices
+! Adaptee pour la matrice de mueller complete
+! F.Malaval 20/04/2023
+!*************************************************************
+
+  integer, intent(in) :: lambda, p_lambda
+
+  real(kind=dp), parameter :: dtheta = pi/real(nang_scatt)
+  real(kind=dp) :: density, theta, norme, fact, k_sca_tot
+  real :: mu, g, g2, s11
+
+  integer :: icell, k, l
+
+  fact = AU_to_cm * mum_to_cm**2
+  !write(*,*) "Computing local scattering properties", lambda, p_lambda
+
+  !$omp parallel &
+  !$omp default(none) &
+  !$omp shared(tab_mueller, tab_mueller_pos) &
+  !$omp shared(lambda,p_lambda,n_grains_tot,tab_albedo_pos,prob_s11_pos) &
+  !$omp shared(zmax,kappa,kappa_abs_LTE,ksca_CDF,p_n_cells,fact) &
+  !$omp shared(C_ext,C_sca,densite_pouss,S_grain,scattering_method,tab_g_pos,aniso_method,tab_g,lisotropic,low_mem_scattering) &
+  !$omp shared(lscatt_ray_tracing,letape_th,lsepar_pola,ldust_prop,lphase_function_file,s11_file) &
+  !$omp private(icell,k,density,norme,theta,k_sca_tot,mu,g,g2, s11)
+  !$omp do schedule(dynamic,1)
+  do icell=1, p_n_cells
+     if (aniso_method==1) then
+        tab_mueller_pos(:,:,:,icell,p_lambda) = 0.
+     endif
+
+     do  k=1,n_grains_tot
+        density=densite_pouss(k,icell)
+        if (aniso_method==1) then
+           ! Moyennage matrice de mueller (long en cpu ) (le dernier indice est l'angle)
+           ! tab_s11 est normalisee a Qsca --> facteur S_grain * density pour que
+           ! tab_s11_pos soit normalisee a k_sca_tot
+           if (lsepar_pola) then
+              tab_mueller_pos(:,:,:,icell,p_lambda) = tab_mueller_pos(:,:,:,icell,p_lambda) + &
+               tab_mueller(:,:,:,k,lambda) * S_grain(k) * density
+           else !on a seulement besoin de S11
+              tab_mueller_pos(1,1,:,icell,p_lambda) = tab_mueller_pos(1,1,:,icell,p_lambda) + &
+               tab_mueller(1,1,:,k,lambda) * S_grain(k) * density
+           endif
+        endif !aniso_method
+     enddo !k
+
+     k_sca_tot = kappa(icell,lambda) * tab_albedo_pos(icell,lambda) / fact ! We renormalize to remove the factor from opacity
+
+     ! Over-riding phase function
+     if (lphase_function_file)  then
+        tab_mueller_pos(1,1,:,icell,p_lambda) = s11_file(:)
+
+        ! Normalisation of phase-function to k_sca_tot, ie like the internal routines
+        norme = 0.0
+        do l=1,nang_scatt-1 ! on saute j=0 & nang_scatt car sin(theta) = 0
+           theta = real(l)*dtheta
+           norme = norme + tab_mueller_pos(1,1,l,icell,p_lambda)*sin(theta)*dtheta
+        enddo
+        tab_mueller_pos(1,1,:,icell,p_lambda) = tab_mueller_pos(1,1,:,icell,p_lambda) * k_sca_tot / norme
+     endif
+
+     if (k_sca_tot > tiny_real) then
+
+        if (aniso_method==1) then ! full phase function
+           ! Propri\E9t\E9s optiques des cellules
+           prob_s11_pos(0,icell,p_lambda)=0.0
+
+           do l=2,nang_scatt ! probabilite de diffusion jusqu'a l'angle j, on saute j=0 car sin(theta) = 0
+              theta = real(l)*dtheta
+              prob_s11_pos(l,icell,p_lambda)=prob_s11_pos(l-1,icell,p_lambda)+ &
+                   tab_mueller_pos(1,1,l,icell,p_lambda)*sin(theta)*dtheta
+           enddo
+
+           ! tab_mueller_pos(1,1) est calculee telle que la normalisation soit: k_sca_tot
+           ! car tab_mueller(1,1) est normalisÃ© Ã  Qsca
+           prob_s11_pos(1:nang_scatt,icell,p_lambda) = prob_s11_pos(1:nang_scatt,icell,p_lambda) + &
+                k_sca_tot - prob_s11_pos(nang_scatt,icell,p_lambda)
+           
+           
+           ! Normalisation de la proba cumulee a 1
+           prob_s11_pos(:,icell,p_lambda)=prob_s11_pos(:,icell,p_lambda)/k_sca_tot
+           
+           ! Normalisation des matrices de Mueller (idem que dans mueller_Mie)
+           do l=0,nang_scatt
+              if (tab_mueller_pos(1,1,l,icell,p_lambda) > tiny_real) then
+                 s11 = tab_mueller_pos(1,1,l,icell,p_lambda)
+                 norme=1.0/s11
+                 if (lsepar_pola) then
+                    tab_mueller_pos(:,:,l,icell,p_lambda)= tab_mueller_pos(:,:,l,icell,p_lambda) *norme
+                    tab_mueller_pos(1,1,l,icell,p_lambda) = s11
+                 endif
+              else 
+                 write (*,*) "Error : at angle", real(l)*pi/real(nang_scatt)
+                 call error ("local s11 = 0.0")
+              endif
+           enddo
+
+
+           ! Normalisation : on veut que l'energie total diffusee sur [0,pi] en theta et [0,2pi] en phi = 1
+           ! (for ray-tracing)
+           tab_mueller_pos(1,1,:,icell,p_lambda) = tab_mueller_pos(1,1,:,icell,p_lambda) * dtheta / (k_sca_tot * deux_pi)
+
+
+           ! -- ! aniso_method = 2 --> HG
+           ! -- gsca = tab_g_pos(icell,lambda)
+           ! -- tab_s11_ray_tracing(:,icell,lambda) =  tab_s11_ray_tracing(:,icell,lambda) / (k_sca_tot * deux_pi)
+           ! --
+           ! -- if (lisotropic) tab_s11_ray_tracing(:,icell,lambda) = 1.0 / (4.* nang_scatt)
+        else !aniso_method == 2 : HG
+
+           call error ("You shoudn't use a hg function option when putting Mueller matrix in input")
+        endif !aniso_method
+
+
+        ! todo :
+        ! utiliser tab_s11_pos pour raie tracing et tab_s12_o_s11
+        ! 1) normaliser les tab_s12_o_s11
+        ! 2) normaliser les tab_s11 avec  norme = dtheta / (k_sca_tot * deux_pi)
+
+        ! Multi ou mono-lambda : mono-lambda si 180 * p_n_cells * p_n_lambda >> 1
+        ! 1) p_n_lambda = n_lambda au step 1
+        ! 2) p_n_lambda = 1 au step 2 si p_n_cells > 1, sinon on peut utiliser n_lambda
+        ! 3) on ne recalcule pas si fait au step 1
+
+     else ! k_sca_tot = 0.0
+        tab_albedo_pos(icell,lambda)=0.0
+        ! Propri\E9t\E9s optiques des cellules
+        prob_s11_pos(:,icell,p_lambda)=1.0
+        prob_s11_pos(0,icell,p_lambda)=0.0
+        ! Normalisation (idem que dans mueller)
+        tab_mueller_pos(:,:,:,icell,p_lambda)=0.0
+        tab_mueller_pos(1,1,:,icell,p_lambda)=1.0
+
+     endif ! k_sca_tot > or = 0
+  enddo !icell
+  !$omp enddo
+  !$omp end parallel
+
+  return
+
+end subroutine calc_local_scattering_matrices_mueller
 
 !******************************************************************************
 
@@ -1257,6 +1440,8 @@ end function select_scattering_grain
 !*******************************************************************
 
 subroutine write_dust_prop()
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   use fits_utils, only : cfitsWrite
   use density, only : masse
@@ -1298,13 +1483,21 @@ subroutine write_dust_prop()
   call cfitsWrite("!data_dust/kappa_grain.fits.gz",kappa_grain,shape(kappa_grain)) ! lambda, n_grains
 
   do l=1, n_lambda
-     S11_lambda_theta(l,:)= tab_s11_pos(:,p_icell,l)
+     if (lmueller) then
+        S11_lambda_theta(l,:)= tab_mueller_pos(1,1,:,p_icell,l)
+     else
+        S11_lambda_theta(l,:)= tab_s11_pos(:,p_icell,l)
+     endif
   enddo
   call cfitsWrite("!data_dust/phase_function.fits.gz",S11_lambda_theta,shape(S11_lambda_theta))
 
   if (lsepar_pola) then
      do l=1, n_lambda
-        pol_lambda_theta(l,:) = -tab_s12_o_s11_pos(:,p_icell,l) ! Deja normalise par S11
+        if (lmueller) then
+           pol_lambda_theta(l,:) = -tab_mueller_pos(1,2,:,p_icell,l) ! Deja normalise par S11
+        else
+           pol_lambda_theta(l,:) = -tab_s12_o_s11_pos(:,p_icell,l) ! Deja normalise par S11
+        endif
      enddo
      call cfitsWrite("!data_dust/polarizability.fits.gz",pol_lambda_theta,shape(pol_lambda_theta))
   endif

--- a/src/dust_transfer.f90
+++ b/src/dust_transfer.f90
@@ -39,6 +39,8 @@ module dust_transfer
   contains
 
 subroutine transfert_poussiere()
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   use thermal_emission, only : frac_E_stars, frac_E_disk
 
@@ -211,8 +213,13 @@ subroutine transfert_poussiere()
      p_icell = icell_ref
      if (aniso_method==2) write(*,*) "g             ", tab_g_pos(p_icell,1)
      write(*,*) "albedo        ", tab_albedo_pos(p_icell,1)
-     if (lsepar_pola.and.(scattering_method == 2)) write(*,*) "polarisability", maxval(-tab_s12_o_s11_pos(:,p_icell,1))
-
+     if (lsepar_pola.and.(scattering_method == 2)) then
+        if (lmueller) then
+           write(*,*) "polarisability", maxval(-tab_mueller_pos(1,2,:,p_icell,1))
+        else
+           write(*,*) "polarisability", maxval(-tab_s12_o_s11_pos(:,p_icell,1))
+        endif
+     endif
      if (lopacite_only) call exit(0)
 
      if (l_em_disk_image) then ! le disque �met
@@ -468,7 +475,13 @@ subroutine transfert_poussiere()
 
         lambda = ind_etape - first_etape_obs + 1
 
-        if (.not.lMueller_pos_multi .and. lscatt_ray_tracing) call calc_local_scattering_matrices(lambda, p_lambda)
+        if (.not.lMueller_pos_multi .and. lscatt_ray_tracing) then
+           if (lmueller) then 
+              call calc_local_scattering_matrices_mueller(lambda, p_lambda)
+           else
+              call calc_local_scattering_matrices(lambda, p_lambda)
+           endif
+        endif
 
         if (lspherical.or.l3D) then
            call no_dark_zone()
@@ -957,6 +970,8 @@ end subroutine emit_packet
 subroutine propagate_packet(id,lambda,p_lambda,icell,x,y,z,u,v,w,stokes,flag_star,flag_ISM,flag_scatt,lpacket_alive)
   ! C. Pinte
   ! 27/05/09
+  ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+  ! 20/04/2023
 
   ! - flag_star_direct et flag_scatt a initialiser : on a besoin des 2
   ! - separer 1ere diffusion et reste
@@ -1065,8 +1080,10 @@ subroutine propagate_packet(id,lambda,p_lambda,icell,x,y,z,u,v,w,stokes,flag_sta
               call cdapres(cospsi, phi, u, v, w, u1, v1, w1)
               if (lsepar_pola) then
                  ! Nouveaux param�tres de Stokes
-                 if (laggregate) then
-                    call new_stokes_gmm(lambda,itheta,rand2,taille_grain,u,v,w,u1,v1,w1,stokes)
+                 if (lmueller) then
+                    call new_stokes_mueller(lambda,itheta,rand2,taille_grain,u,v,w,u1,v1,w1,stokes)
+                 else if (laggregate) then
+                    call  new_stokes_gmm(lambda,itheta,rand2,taille_grain,u,v,w,u1,v1,w1,stokes)
                  else
                     call new_stokes(lambda,itheta,rand2,taille_grain,u,v,w,u1,v1,w1,stokes)
                  endif
@@ -1100,7 +1117,13 @@ subroutine propagate_packet(id,lambda,p_lambda,icell,x,y,z,u,v,w,stokes,flag_sta
               ! direction de propagation apres diffusion
               call cdapres(cospsi, phi, u, v, w, u1, v1, w1)
               ! Nouveaux param�tres de Stokes
-              if (lsepar_pola) call new_stokes_pos(p_lambda,itheta,rand2,p_icell,u,v,w,u1,v1,w1,Stokes)
+              if (lsepar_pola) then 
+                 if (lmueller) then
+                    call new_stokes_mueller_pos(p_lambda,itheta,rand2,p_icell,u,v,w,u1,v1,w1,Stokes)
+                 else 
+                    call new_stokes_pos(p_lambda,itheta,rand2,p_icell,u,v,w,u1,v1,w1,Stokes)
+		 endif
+	      endif 
            else ! fonction de phase HG
               call hg(tab_g_pos(p_icell,lambda),rand, itheta, cospsi) !HG
               if (lisotropic)  then ! Diffusion isotrope

--- a/src/grains.f90
+++ b/src/grains.f90
@@ -63,8 +63,9 @@ module grains
   ! Parametres de diffusion des cellules
   real, dimension(:,:), allocatable :: tab_albedo_pos, tab_g_pos ! n_cells,n_lambda
   real, dimension(:,:,:), allocatable :: tab_s11_pos, tab_s12_o_s11_pos, tab_s33_o_s11_pos, tab_s34_o_s11_pos, prob_s11_pos ! 0:180, n_cells,n_lambda
+  real, dimension(:,:,:,:,:), allocatable :: tab_mueller_pos ! 4,4,0:180, n_cells,n_lambda
 
-  character(len=512) :: aggregate_file, mueller_aggregate_file
+  character(len=512) :: aggregate_file, mueller_aggregate_file, mueller_file
   real :: R_sph_same_M
 
 end module grains

--- a/src/init_mcfost.f90
+++ b/src/init_mcfost.f90
@@ -211,6 +211,7 @@ subroutine set_default_variables()
   theta_max = 0.5*pi
   llinear_rgrid = .false.
   image_offset_centre(:) = (/0.0,0.0,0.0/)
+  loverwrite_s12 = .false.
 
   tmp_dir = "./"
 
@@ -480,7 +481,7 @@ subroutine initialisation_mcfost()
         i_arg = i_arg+1
      case("-split_image")
          lsepar_ori = .true.
-         i_arg = i_arg + 1            
+         i_arg = i_arg + 1
      case("-op")
         limg=.true.
         lopacite_only=.true.
@@ -1440,6 +1441,12 @@ subroutine initialisation_mcfost()
      case("-old_PA")
         i_arg = i_arg + 1
         lold_PA = .true.
+     case("-Pmax")
+        loverwrite_s12 = .true.
+        i_arg = i_arg + 1
+        call get_command_argument(i_arg,s)
+        read(s,*) Pmax
+        i_arg = i_arg + 1
       case default
         write(*,*) "Error: unknown option: "//trim(s)
         write(*,*) "Use 'mcfost -h' to get list of available options"
@@ -1886,6 +1893,7 @@ subroutine display_help()
   write(*,*) "        : -turn-off_dust_subl : ignore dust sublimation"
   write(*,*) "        : -img_offset <x0> <y0> <z0> : Centres the observer's los in (x0,y0,z0)"
   write(*,*) "        : -split_image : Split a fits image in a fits file for each orienation (incl,azim)"
+  write(*,*) "        : -Pmax <calue> : force s12 to be a bell shape peaking at Pmax (between 0 and 1)"
   write(*,*) " "
   write(*,*) " Options related to temperature equilibrium"
   write(*,*) "        : -no_T : skip temperature calculations, force ltemp to F"

--- a/src/init_mcfost.f90
+++ b/src/init_mcfost.f90
@@ -23,6 +23,8 @@ module init_mcfost
 contains
 
 subroutine set_default_variables()
+  ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+  ! 20/04/2023
 
   ! Pour code sequentiel
   nb_proc=1 ; lpara=.false.
@@ -44,6 +46,8 @@ subroutine set_default_variables()
   limg=.false.
   lorigine=.false.
   laggregate=.false.
+  lmueller=.false.
+  lper_size = .false.
   l3D=.false.
   lopacite_only=.false.
   lseed=.false.
@@ -265,6 +269,8 @@ end subroutine get_mcfost_utils_dir
 !**********************************************
 
 subroutine initialisation_mcfost()
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   implicit none
 
@@ -507,11 +513,30 @@ subroutine initialisation_mcfost()
      case("-aggregate")
         laggregate=.true.
         i_arg = i_arg+1
+        if (lmueller) call error ("You can't use both -aggregate and -mueller options")
+        if (lper_size) call error ("You can't use both -aggregate and -mueller_size options")
         if (i_arg > nbr_arg) call error("GMM input file needed")
         call get_command_argument(i_arg,aggregate_file)
         i_arg = i_arg+1
         if (i_arg > nbr_arg) call error("GMM input file needed")
         call get_command_argument(i_arg,mueller_aggregate_file)
+     case("-mueller")
+        lmueller=.true.
+        i_arg = i_arg+1
+        if (laggregate) call error ("You can't use both  -mueller and -aggregate options")
+        if (lper_size) call error ("You can't use both -mueller and -mueller_size options")
+        if (i_arg > nbr_arg) call error("Mueller input file needed")
+        call get_command_argument(i_arg,mueller_file)
+        i_arg = i_arg+1
+     case("-mueller_size")
+        lper_size = .true.
+        i_arg = i_arg+1
+        if (laggregate) call error ("You can't use both -mueller_size and -aggregate options")
+        if (lmueller) call error ("You can't use both -mueller_size and -mueller options")
+        lmueller=.true.
+        if (i_arg > nbr_arg) call error("Mueller input pathfile needed")
+        call get_command_argument(i_arg,mueller_file)
+        i_arg = i_arg+1
      case("-3D")
         l3D=.true.
         i_arg = i_arg+1
@@ -1790,6 +1815,8 @@ end subroutine initialisation_mcfost
 !********************************************************************
 
 subroutine display_help()
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   implicit none
 
@@ -1915,6 +1942,30 @@ subroutine display_help()
   write(*,*) "        : -op <wavelength> (microns) : computes dust properties at"
   write(*,*) "                                    specified wavelength and stops"
   write(*,*) "        : -aggregate <GMM_input_file> <GMM_output_file>"
+  write(*,*) "        : -mueller <Mueller_input_file> "
+  write(*,*) "     "
+  write(*,*) "        Mueller_input_file contain the mean mueller matrix averaged"
+  write(*,*) "        over the size distribution. Every element is divided by s11."
+  write(*,*) "        The format of the input file must be the following."
+  write(*,*) "     "
+  write(*,*) "             Qext        Qsca        <cos(theta)> "
+  write(*,*) "          Qext_value  Qsca_value  <cos(theta)>_value "
+  write(*,*) "     "
+  write(*,*) "     "
+  write(*,*) "                               Mueller Scattering Matrix "
+  write(*,*) "       an_value   s11_value   s12_value   s13_value    s14_value "
+  write(*,*) "                  s21_value   s22_value   s23_value    s24_value "
+  write(*,*) "                  s31_value   s32_value   s33_value    s34_value "
+  write(*,*) "                  s41_value   s42_value   s43_value    s44_value "
+  write(*,*) "       an_value   s11_value   s12_value   s13_value    s14_value "
+  write(*,*) "                  s21_value   s22_value   s23_value    s24_value "
+  write(*,*) "     ....... "
+  write(*,*) "     "
+  write(*,*) "        : -mueller_size <Mueller_input_pathfile> "
+  write(*,*) "                   Argument pathfile contain the size of each grain, and the path"
+  write(*,*) "                   for each associated matrix for every grain size, sorted" 
+  write(*,*) "                   from the first to the last grain size considered."
+  write(*,*) "     "
   write(*,*) "        : -optical_depth_map ot -tau_map   : create an map of the optical depth"
   write(*,*) "        : -tau=1_surface : creates a map of the tau=1 surface"
   write(*,*) "        : -tau_surface <tau> : creates a map of the tau=<tau> surface"

--- a/src/mem.f90
+++ b/src/mem.f90
@@ -55,6 +55,8 @@ end subroutine deallocate_densities
 !*****************************************************************
 
 subroutine alloc_dust_prop()
+ ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+ ! 20/04/2023
 
   integer ::  alloc_status
 
@@ -75,26 +77,26 @@ subroutine alloc_dust_prop()
   ! **************************************************
   ! tableaux relatifs aux prop optiques des grains
   ! **************************************************
-  allocate(tab_s11(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s11')
-  tab_s11 = 0
-
-  allocate(tab_s12(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s12')
-  tab_s12 = 0
-
-  allocate(tab_s33(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s33')
-  tab_s33 = 0
-
-  allocate(tab_s34(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s34')
-  tab_s34 = 0
-
-  if (laggregate) then
+  if (laggregate.or.lmueller) then
      allocate(tab_mueller(4,4,0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
      if (alloc_status > 0) call error('Allocation error tab_mueller')
      tab_mueller = 0
+  else 
+     allocate(tab_s11(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s11')
+     tab_s11 = 0
+
+     allocate(tab_s12(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s12')
+     tab_s12 = 0
+
+     allocate(tab_s33(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s33')
+     tab_s33 = 0
+
+     allocate(tab_s34(0:nang_scatt,n_grains_tot,n_lambda), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s34')
+     tab_s34 = 0
   endif
 
   allocate(prob_s11(n_lambda,n_grains_tot,0:nang_scatt), stat=alloc_status)
@@ -110,9 +112,11 @@ end subroutine alloc_dust_prop
 subroutine alloc_dynamique(n_cells_max)
   ! Alloue les tableaux dynamiquement en fonction de l'organisation
   ! des calculs, de la presence de stratification ...
-  ! Permet d'optimiser la taille mémoire
+  ! Permet d'optimiser la taille mÃ©moire
   ! C. Pinte
   ! 12/05/05
+  ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+  ! 20/04/2023
 
   use stars, only : allocate_stellar_spectra
   use thermal_emission, only : allocate_temperature, allocate_thermal_emission, &
@@ -209,23 +213,29 @@ subroutine alloc_dynamique(n_cells_max)
      endif
      if (mem_size > 1) write(*,*) "Trying to allocate", mem_size, "GB for scattering matrices"
 
-     allocate(tab_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), stat=alloc_status)
-     if (alloc_status > 0) call error('Allocation error tab_s11_pos')
-     tab_s11_pos = 0
-
      allocate(prob_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), stat=alloc_status)
      if (alloc_status > 0) call error('Allocation error prob_s11_pos')
      prob_s11_pos = 0
 
-     if (lsepar_pola) then
-        allocate(tab_s12_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
-             tab_s33_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
-             tab_s34_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
-             stat=alloc_status)
-        if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
-        tab_s12_o_s11_pos = 0
-        tab_s33_o_s11_pos = 0
-        tab_s34_o_s11_pos = 0
+     if (lmueller) then 
+     	allocate(tab_mueller_pos(4,4,0:nang_scatt, p_Nc, p_n_lambda_pos), stat=alloc_status)
+     	if (alloc_status > 0) call error('Allocation error tab_mueller_pos')
+     	tab_mueller_pos = 0
+     else 
+	allocate(tab_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), stat=alloc_status)
+	if (alloc_status > 0) call error('Allocation error tab_s11_pos')
+	tab_s11_pos = 0
+
+	if (lsepar_pola) then
+	   allocate(tab_s12_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
+		    tab_s33_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
+		    tab_s34_o_s11_pos(0:nang_scatt, p_Nc, p_n_lambda_pos), &
+		    stat=alloc_status)
+	   if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
+	   tab_s12_o_s11_pos = 0
+	   tab_s33_o_s11_pos = 0
+	   tab_s34_o_s11_pos = 0
+	endif
      endif
   else ! scattering method==1 --> prop par grains
      mem_size = (1.0 * n_grains_tot) * p_Nc * n_lambda * 4. / 1024.**3
@@ -304,6 +314,8 @@ end subroutine alloc_dynamique
 !**********************************************************************
 
 subroutine deallocate_em_th_mol()
+ ! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+ ! 20/04/2023
 
   use thermal_emission, only : deallocate_thermal_emission
   use stars, only : deallocate_stellar_spectra
@@ -331,13 +343,21 @@ subroutine deallocate_em_th_mol()
   if (allocated(tab_g_pos)) deallocate(tab_g_pos)
 
   if (scattering_method == 2) then ! prop par cellule
-     deallocate(tab_s11_pos,prob_s11_pos)
-     if (lsepar_pola) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
+     if (lmueller) then
+        deallocate(tab_mueller_pos,prob_s11_pos)
+     else
+        deallocate(tab_s11_pos,prob_s11_pos)
+        if (lsepar_pola) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
+     endif
   else ! prop par grains
      if (allocated(ksca_CDF)) deallocate(ksca_CDF)
   endif ! method
 
-  deallocate(tab_s11,tab_s12,tab_s33,tab_s34,prob_s11)
+  if (lmueller.or.laggregate) then
+     deallocate (tab_mueller, prob_s11)
+  else
+     deallocate(tab_s11,tab_s12,tab_s33,tab_s34,prob_s11)
+  endif
 
   if (lorigine) call deallocate_origin()
 
@@ -427,6 +447,8 @@ end subroutine clean_mem_dust_mol
 !******************************************************************************
 
 subroutine realloc_step2()
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   use dust_ray_tracing, only : select_scattering_method
   use radiation_field, only : allocate_radiation_field_step2
@@ -513,31 +535,31 @@ subroutine realloc_step2()
      tab_g_pos = 0
   endif
 
-  deallocate(tab_s11)
-  allocate(tab_s11(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s11')
-  tab_s11 = 0
-
-  deallocate(tab_s12)
-  allocate(tab_s12(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s12')
-  tab_s12 = 0
-
-  deallocate(tab_s33)
-  allocate(tab_s33(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s33')
-  tab_s33 = 0
-
-  deallocate(tab_s34)
-  allocate(tab_s34(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s34')
-  tab_s34 = 0
-
-  if (laggregate) then
+  if (laggregate.or.lmueller) then
      deallocate(tab_mueller)
      allocate(tab_mueller(4,4,0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
      if (alloc_status > 0) call error('Allocation error tab_mueller')
      tab_mueller = 0
+  else 
+     deallocate(tab_s11)
+     allocate(tab_s11(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s11')
+     tab_s11 = 0
+
+     deallocate(tab_s12)
+     allocate(tab_s12(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s12')
+     tab_s12 = 0
+
+     deallocate(tab_s33)
+     allocate(tab_s33(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s33')
+     tab_s33 = 0
+
+     deallocate(tab_s34)
+     allocate(tab_s34(0:nang_scatt,n_grains_tot,n_lambda2), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s34')
+     tab_s34 = 0
   endif
 
   deallocate(prob_s11)
@@ -546,20 +568,27 @@ subroutine realloc_step2()
   prob_s11 = 0
 
   if (scattering_method == 2) then
-     if (allocated(tab_s11_pos)) deallocate(tab_s11_pos)
-     allocate(tab_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
-     if (alloc_status > 0) call error('Allocation error tab_s11_pos')
+     if (lmueller) then
+        if (allocated(tab_mueller_pos)) deallocate(tab_mueller_pos)
+        allocate(tab_mueller_pos(4,4,0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
+        if (alloc_status > 0) call error('Allocation error tab_mueller_pos')
+        tab_mueller_pos = 0
+     else
+        if (allocated(tab_s11_pos)) deallocate(tab_s11_pos)
+        allocate(tab_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
+        if (alloc_status > 0) call error('Allocation error tab_s11_pos')
 
-     if (lsepar_pola) then
-        if (allocated(tab_s12_o_s11_pos)) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
-        allocate(tab_s12_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-             tab_s33_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-             tab_s34_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-             stat=alloc_status)
-        if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
-        tab_s12_o_s11_pos = 0
-        tab_s33_o_s11_pos = 0
-        tab_s34_o_s11_pos = 0
+        if (lsepar_pola) then
+           if (allocated(tab_s12_o_s11_pos)) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
+           allocate(tab_s12_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+                tab_s33_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+                tab_s34_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+                stat=alloc_status)
+           if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
+           tab_s12_o_s11_pos = 0
+           tab_s33_o_s11_pos = 0
+           tab_s34_o_s11_pos = 0
+        endif
      endif
 
      if (allocated(prob_s11_pos)) deallocate(prob_s11_pos)
@@ -599,7 +628,9 @@ end subroutine realloc_step2
 !**********************************************************************
 
 subroutine realloc_ray_tracing_scattering_matrix()
-
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
+ 
   integer, parameter :: p_n_lambda2_pos = 1
   integer :: alloc_status
 
@@ -608,21 +639,28 @@ subroutine realloc_ray_tracing_scattering_matrix()
   write(*,fmt='(" Using scattering method ",i1)') scattering_method
   lscattering_method1 = (scattering_method==1)
 
-  if (allocated(tab_s11_pos)) deallocate(tab_s11_pos)
-  allocate(tab_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
-  if (alloc_status > 0) call error('Allocation error tab_s11_pos')
-  tab_s11_pos = 0
+  if (lmueller) then
+     if (allocated(tab_mueller_pos)) deallocate(tab_mueller_pos)
+     allocate(tab_mueller_pos(4,4,0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_mueller_pos')
+     tab_mueller_pos = 0
+  else
+     if (allocated(tab_s11_pos)) deallocate(tab_s11_pos)
+     allocate(tab_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), stat=alloc_status)
+     if (alloc_status > 0) call error('Allocation error tab_s11_pos')
+     tab_s11_pos = 0
 
-  if (lsepar_pola) then
-     if (allocated(tab_s12_o_s11_pos)) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
-     allocate(tab_s12_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-          tab_s33_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-          tab_s34_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
-          stat=alloc_status)
-     if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
-     tab_s12_o_s11_pos = 0
-     tab_s33_o_s11_pos = 0
-     tab_s34_o_s11_pos = 0
+     if (lsepar_pola) then
+        if (allocated(tab_s12_o_s11_pos)) deallocate(tab_s12_o_s11_pos,tab_s33_o_s11_pos,tab_s34_o_s11_pos)
+        allocate(tab_s12_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+             tab_s33_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+             tab_s34_o_s11_pos(0:nang_scatt,p_n_cells,p_n_lambda2_pos), &
+             stat=alloc_status)
+        if (alloc_status > 0) call error('Allocation error tab_s12_o_s11_pos')
+        tab_s12_o_s11_pos = 0
+        tab_s33_o_s11_pos = 0
+        tab_s34_o_s11_pos = 0
+     endif
   endif
 
   if (allocated(prob_s11_pos)) deallocate(prob_s11_pos)

--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -121,7 +121,7 @@ module parametres
   logical :: lregular_theta
   real :: theta_max
 
-  logical :: letape_th, limg, lorigine, laggregate, l3D, lremove, lwarp, lcavity, ltilt, lwall
+  logical :: letape_th, limg, lorigine, laggregate, lmueller, lper_size, l3D, lremove, lwarp, lcavity, ltilt, lwall
   logical :: lopacite_only, lseed, ldust_prop, ldisk_struct, lwrite_velocity, loptical_depth_to_cell, ltau_map, lreemission_stats
   logical :: lapprox_diffusion, lcylindrical, lspherical, llinear_rgrid, lVoronoi, is_there_disk, lno_backup
   logical :: laverage_grain_size, lisotropic, lno_scattering, lqsca_equal_qabs, lonly_diff_approx, lforce_diff_approx

--- a/src/parameters.f90
+++ b/src/parameters.f90
@@ -64,7 +64,7 @@ module parametres
   logical :: lemission_atom, lelectron_scattering, lforce_lte,  &
             	ldissolve, loutput_rates, lzeeman_polarisation
   integer :: N_rayons_mc, istep_start, istep_end
- 
+
   !HEALpix
   integer :: healpix_lorder, healpix_lmin, healpix_lmax !lmin and lmax not yet (for local evaluation)
 
@@ -161,6 +161,10 @@ module parametres
   ! Disk parameters
   real :: distance ! Distance du disque en pc
   real(kind=dp) :: map_size
+
+  ! Polarisation
+  logical :: loverwrite_s12
+  real :: Pmax
 
   integer :: n_zones, n_regions
 

--- a/src/scattering.f90
+++ b/src/scattering.f90
@@ -311,7 +311,6 @@ end subroutine BHMIE
 
 !***************************************************
 
-
 subroutine mueller_Mie(lambda,taille_grain,x,amu1,amu2, qext,qsca,gsca)
 !***************************************************************
 ! calcule les elements de la matrice de diffusion a partir de
@@ -409,6 +408,26 @@ subroutine mueller_Mie(lambda,taille_grain,x,amu1,amu2, qext,qsca,gsca)
   return
 
 end subroutine mueller_Mie
+
+!***************************************************
+
+subroutine overwrite_s12(Pmax)
+
+  real, intent(in) :: Pmax
+
+  real :: dtheta, theta
+  integer :: j
+
+  dtheta = pi/real(nang_scatt)
+  do j=0,nang_scatt
+     theta = real(j)*dtheta
+     tab_s12(j,:,:) = - Pmax * (1-(cos(theta))**2)
+  enddo
+
+  return
+
+end subroutine overwrite_s12
+
 
 !***************************************************
 

--- a/src/scattering.f90
+++ b/src/scattering.f90
@@ -143,8 +143,8 @@ subroutine bhmie(x,refrel,nang,s1,s2,qext,qsca,qback,gsca)
 ! 93/06/01 (BTD): Changed AMAX1 to generic function MAX
 ! 04/03/04 (CP): passage en fortran 90
 ! 13/10/04 (CP): passage a des angles demi-entier (milieu du bin) pour pouvoir faire l'integration de s11(theta)
-! l'angle 0� est calcule a part car on en a besoin pour Qext
-! de meme, on aurait besoin de 180� pour Qback mais ca ne sert pas donc je ne calcule pas
+! l'angle 0° est calcule a part car on en a besoin pour Qext
+! de meme, on aurait besoin de 180° pour Qback mais ca ne sert pas donc je ne calcule pas
 ! 16/12/04 (CP): Remplacement imag par aimag (Pas forcement ok avec tous les
 ! compilateurs) mais standard f95 et 2003
 ! 24/03/05 (CP): allocation dynamique de D. Permet de placer le tableau dans la zone data
@@ -415,8 +415,8 @@ end subroutine mueller_Mie
 subroutine mueller_GMM(lambda,taille_grain, qext,qsca,gsca)
 !***************************************************************
 ! calcule les elements de la matrice de diffusion a partir du
-! code gmm01TrA (clusters de sph�res)
-!     Aggr�gats
+! code gmm01TrA (clusters de sphères)
+!     Aggrégats
 !
 !        CALCULE AUSSI "G" = LE PARAMETRE D'ASYMETRIE
 !
@@ -456,7 +456,7 @@ subroutine mueller_GMM(lambda,taille_grain, qext,qsca,gsca)
   if(n_grains_tot > 1) call error("You must choose n_grains_tot=1")
   if (scattering_method /= 1) call error("You must choose scattering_method 1")
 
-  ! Lecture du fichier de r�sultats de gmm01TrA : 'gmm01TrA.out'
+  ! Lecture du fichier de résultats de gmm01TrA : 'gmm01TrA.out'
   open(unit=12,file=mueller_aggregate_file,status='old')
   read(12,*)
   read(12,*)
@@ -501,7 +501,7 @@ subroutine mueller_GMM(lambda,taille_grain, qext,qsca,gsca)
 
 !  QABS=QEXT-QSCA
 ! Calcul des elements de la matrice de diffusion
-! Calcul angle central du bin par interpolation lin�aire
+! Calcul angle central du bin par interpolation linéaire
   do J=1,2*NANG_scatt
      mueller(:,:,j) = 0.5*(mue(:,:,j)+mue(:,:,j+1))
   enddo !j
@@ -555,6 +555,288 @@ subroutine mueller_GMM(lambda,taille_grain, qext,qsca,gsca)
 end subroutine mueller_GMM
 
 !***************************************************
+
+subroutine mueller_input(lambda,taille_grain, qext,qsca,gsca)
+
+!***************************************************************
+! Routine dérivé de Mueller_GMM.
+! Calcule les elements de la matrice de diffusion a partir d'un
+! fichier ascii contenant divers informations : 
+! La matrice de Mueller à chaque angle de diffraction de 0 à 180°,
+! Qsca, Qext et le facteur d'assymétrie
+! Voici un exemple de fichier :
+!        Qext        Qsca        <cos(theta)>
+!     0.34402E+01  0.82702E+00     0.73069E+00
+!
+!
+!                          Mueller Scattering Matrix
+!    0.0   0.7171184E+04   0.1608979E+03  -0.1360425E-13 0.1008702E-12
+!          0.1608979E+03   0.7171184E+04   0.1085675E-13 -0.1342563E-13
+!         -0.1281373E-13  -0.1100342E-13   0.7169003E+04 0.7345735E+02
+!          0.1013335E-12   0.1580635E-13  -0.7345735E+02 0.7169003E+04
+!    1.0   0.6996034E+04   0.1585395E+03  -0.1087324E-12 -0.2014537E-12
+!          0.1585395E+03   0.6996034E+04   0.7065835E-13 -0.1650172E-12
+!.......
+!
+!
+! F. Malaval
+! 20/04/2023
+!****************************************************************
+
+  implicit none
+
+  integer, intent(in) :: lambda, taille_grain
+  real, intent(out) :: qext, qsca, gsca
+  
+  integer :: j, i
+
+  real :: norme, somme_prob, theta, dtheta
+  real :: ext,sca,assym
+  
+  real, dimension(0:nang_scatt) :: dang
+
+  real, dimension(4,4,0:nang_scatt) :: mueller
+
+  character(len=128) :: string
+  
+  if (modulo(nang_scatt,2) == 1) call error("nang_scatt must be an EVEN number")
+  
+  if (aniso_method == 2) call error ("You shoudn't use a hg function option when putting Mueller matrix in input")
+
+  ! Lecture du fichier d'entrée :
+  open(unit=12,file=mueller_file,status='old')
+  read(12,*) string
+  read(12,*) ext,sca,assym 
+  read(12,*)
+  read(12,*)  !'Matrice de mueller (4X4 coefficients pour chaque angle):'
+  read(12,*) string
+  do i=0,nang_scatt
+	read(12,*) dang(i),mueller(1,1,i),mueller(1,2,i),mueller(1,3,i),mueller(1,4,i)
+	read(12,*)         mueller(2,1,i),mueller(2,2,i),mueller(2,3,i),mueller(2,4,i)
+	read(12,*)         mueller(3,1,i),mueller(3,2,i),mueller(3,3,i),mueller(3,4,i)
+	read(12,*)         mueller(4,1,i),mueller(4,2,i),mueller(4,3,i),mueller(4,4,i)
+  enddo
+  close(12)
+  ! Fin lecture
+
+  close(unit=1)
+
+  if (scattering_method == 1) then
+	  ! Integration de S11 pour tirer angle
+	  ! Condition initiale : sin(0)=0
+	  prob_s11(lambda,taille_grain,0)=0.0
+	  dtheta = pi/real(nang_scatt)
+
+	  do j=1,nang_scatt  
+	     theta = real(j)*dtheta
+	     prob_s11(lambda, taille_grain,j)=prob_s11(lambda, taille_grain,j-1)+&
+		  mueller(1,1,j)*sin(theta)*dtheta
+	  enddo
+	  
+	  ! Normalisation
+	  somme_prob = prob_s11(lambda, taille_grain,nang_scatt)
+	  prob_s11(lambda, taille_grain,:)=prob_s11(lambda, taille_grain,:)/somme_prob
+  
+  
+  else  !on va avoir besoin des valeurs non normalisés
+  	do i=1, 4 
+  	   do j=1, 4
+  	      if (i*j>1) mueller(i,j,:) = mueller(i,j,:)*mueller(1,1,:)
+  	   enddo
+  	enddo
+  	!on calcul maintenant l'intégrale de s11
+  	somme_prob=0.0
+	dtheta = pi/real(nang_scatt)
+  	do j=1,nang_scatt
+  	   theta = real(j)*dtheta
+	   somme_prob = somme_prob + mueller(1,1,j)*sin(theta)*dtheta
+  	enddo
+  endif !scatt_meth
+
+
+  do J=0,NANG_scatt
+        if (scattering_method==1) then ! Matrice de Mueller par grain
+        ! Normalisation pour diffusion selon fonction de phase (tab_s11=1.0 sert dans stokes)
+        ! on ne normalise que S11 car les données sont déjà normalisées
+           norme=mueller(1,1,j)
+           if (norme > tiny_real) then
+              mueller(1,1,j) = mueller(1,1,j) / norme 
+           else 
+              write (*,*) "at angle", real(j)*pi/real(nang_scatt)
+              call error ("s11=0.0")
+           endif
+        else ! Sinon normalisation a Qsca. On utilise somme_prob.
+           norme = somme_prob/sca
+           if (norme > tiny_real) then 
+              mueller(:,:,j) = mueller(:,:,j)/norme
+           else 
+              call error ("Error : s11 is normalised to 0")
+           endif 
+        endif
+        
+        tab_mueller(:,:,j,taille_grain,lambda) = mueller(:,:,j)
+  enddo
+  qext = ext
+  qsca = sca
+  gsca = assym
+  if (lforce_HG)  gsca = forced_g
+  if (lisotropic)  gsca = 0.0 
+
+  return
+
+end subroutine mueller_input
+
+
+!***************************************************
+  
+ subroutine mueller_input_size(lambda,taille_grain, qext,qsca,gsca)
+
+!***************************************************************
+! Routine dérivé de Mueller_GMM.
+! Calcule les elements de la matrice de diffusion a partir d'un
+! fichier ascii par taille de grain contenant divers informations : 
+! La matrice de Mueller à chaque angle de diffraction de 0 à 180°
+! Qsca, Qext, le facteur d'assymétrie
+! Voici un exemple de fichier :
+!        Qext        Qsca        <cos(theta)>
+!     0.34402E+01  0.82702E+00     0.73069E+00
+!
+!
+!                          Mueller Scattering Matrix
+!    0.0   0.7171184E+04   0.1608979E+03  -0.1360425E-13 0.1008702E-12
+!          0.1608979E+03   0.7171184E+04   0.1085675E-13 -0.1342563E-13
+!         -0.1281373E-13  -0.1100342E-13   0.7169003E+04 0.7345735E+02
+!          0.1013335E-12   0.1580635E-13  -0.7345735E+02 0.7169003E+04
+!    1.0   0.6996034E+04   0.1585395E+03  -0.1087324E-12 -0.2014537E-12
+!          0.1585395E+03   0.6996034E+04   0.7065835E-13 -0.1650172E-12
+!.......
+!
+! L'adresse de ces fichiers est contenu dans un fichier texte
+! trié dans l'ordre croissant suivant la taille de grain.
+!
+! F. Malaval
+! 20/04/2023
+!****************************************************************
+
+  implicit none
+
+  integer, intent(in) :: lambda, taille_grain
+  real, intent(out) :: qext, qsca, gsca
+  
+  integer :: j, i
+
+  real :: norme, somme_prob, theta, dtheta
+  real :: ext,sca,assym, size
+  
+  real, dimension(0:nang_scatt) :: dang
+
+  real, dimension(4,4,0:nang_scatt) :: mueller
+  
+  character(len=128) :: string, path
+  
+  if (modulo(nang_scatt,2) == 1) call error("nang_scatt must be an EVEN number")
+  
+  if (aniso_method == 2) call error ("You shoudn't use a hg function option when putting Mueller matrix in input")
+  
+  
+  open(unit=13, file = mueller_file, status = 'old') 
+  !Dans ce cas, mueller_file contient les chemins vers les fichiers de chaque matrice, 
+  !triés dans l'ordre croissant suivant la taille de grain.
+  do j=1, taille_grain
+     read(13, *) size, path
+  enddo
+  close(unit=13)
+  if (abs(size-r_grain(taille_grain))>r_grain(taille_grain)*0.00001) then
+      write(*,*) "error, graine size in file is", size, "while expecting", r_grain(taille_grain)
+      call error("The graine sizes does not match") 
+  endif
+
+  ! Lecture du fichier d'entrée :
+  open(unit=12,file=path,status='old')
+  read(12,*) string
+  read(12,*) ext,sca,assym 
+  read(12,*)
+  read(12,*)  !'Matrice de mueller (4X4 coefficients pour chaque angle):'
+  read(12,*) string
+  do i=0,nang_scatt
+	read(12,*) dang(i),mueller(1,1,i),mueller(1,2,i),mueller(1,3,i),mueller(1,4,i)
+	read(12,*)   mueller(2,1,i),mueller(2,2,i),mueller(2,3,i),mueller(2,4,i)
+	read(12,*)   mueller(3,1,i),mueller(3,2,i),mueller(3,3,i),mueller(3,4,i)
+	read(12,*)   mueller(4,1,i),mueller(4,2,i),mueller(4,3,i),mueller(4,4,i)
+  enddo
+  close(12)
+  ! Fin lecture
+
+  close(unit=1)
+  
+  if (scattering_method == 1) then
+	  ! Integration S11 pour tirer angle
+	  ! Condition initiale : sin(0)=0
+	  prob_s11(lambda,taille_grain,0)=0.0
+	  dtheta = pi/real(nang_scatt)
+
+	  do j=1,nang_scatt
+	     theta = real(j)*dtheta
+	     prob_s11(lambda, taille_grain,j)=prob_s11(lambda, taille_grain,j-1)+&
+		  mueller(1,1,j)*sin(theta)*dtheta
+	  enddo
+	  
+	  ! Normalisation
+	  somme_prob= prob_s11(lambda, taille_grain,nang_scatt)
+	  prob_s11(lambda, taille_grain,:)=prob_s11(lambda, taille_grain,:)/somme_prob
+  
+  
+  else  !on va avoir besoin des valeurs non normalisés
+  	do i=1, 4 
+  	   do j=1, 4
+  	      if (i*j>1) mueller(i,j,:) = mueller(i,j,:)*mueller(1,1,:)
+  	   enddo
+  	enddo
+  	!on calcul maintenant l'intégrale de s11
+  	somme_prob=0.0
+	dtheta = pi/real(nang_scatt)
+  	do j=1,nang_scatt
+  	   theta = real(j)*dtheta
+	   somme_prob = somme_prob + mueller(1,1,j)*sin(theta)*dtheta
+  	enddo
+  endif !scatt_meth
+
+
+  do J=0,NANG_scatt
+        if (scattering_method==1) then ! Matrice de Mueller par grain
+        ! Normalisation pour diffusion selon fonction de phase (tab_s11=1.0 sert dans stokes)
+        ! on ne normalise que S11 car les données sont déjà normalisées
+           norme=mueller(1,1,j)
+           if (norme > tiny_real) then
+              mueller(1,1,j) = mueller(1,1,j) / norme 
+           else 
+              write (*,*) "at angle", real(j)*pi/real(nang_scatt)
+              call error ("s11=0.0")
+           endif
+        else ! Sinon normalisation a Qsca. On utilise somme_prob.
+           norme = somme_prob/sca
+           if (norme > tiny_real) then 
+              mueller(:,:,j) = mueller(:,:,j)/norme
+           else 
+              call error ("Error : s11 is normalised to 0")
+           endif 
+        endif
+        
+        tab_mueller(:,:,j,taille_grain,lambda) = mueller(:,:,j)
+  enddo
+  qext = ext
+  qsca = sca
+  gsca = assym
+  if (lforce_HG)  gsca = forced_g
+  if (lisotropic)  gsca = 0.0 
+
+  return
+
+end subroutine mueller_input_size
+
+
+!***************************************************
+
 
 subroutine mueller_opacity_file(lambda,taille_grain, qext,qsca,gsca)
   ! interpolation bi-lineaire (en log-log) des sections efficaces
@@ -746,7 +1028,7 @@ subroutine new_stokes(lambda,itheta,frac,taille_grain,u0,v0,w0,u1,v1,w1,stok)
 !
 !      FRANCOIS MENARD, MONTREAL, 15 FEVRIER 1989
 ! Modif 22/12/03 (C. Pinte) : indice l de taille du grain diffuseur
-! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entr�
+! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
 !***********************************************************
 
   implicit none
@@ -901,8 +1183,8 @@ subroutine new_stokes(lambda,itheta,frac,taille_grain,u0,v0,w0,u1,v1,w1,stok)
 ! LE RESULTAT EST STOK(4,1): LES PARAMETRES DE
 ! STOKES FINAUX
 
-  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entr�
-  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalis� dans mueller2)
+  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
+  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalisé dans mueller2)
   ! I sortant = I entrant * s11 si diff uniforme
 
 !  norme=tab_albedo(l)*tab_s11(itheta,taille_grain,lambda)*(stok_I0/stok(1,1))
@@ -1058,8 +1340,8 @@ subroutine new_stokes_gmm(lambda,itheta,frac,taille_grain,u0,v0,w0,u1,v1,w1,stok
 ! LE RESULTAT EST STOK(4,1): LES PARAMETRES DE
 ! STOKES FINAUX
 
-  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entr�
-  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalis� dans mueller2)
+  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
+  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalisé dans mueller2)
   ! I sortant = I entrant * s11 si diff uniforme
 
 !  norme=tab_albedo(l)*tab_s11(itheta,taille_grain,lambda)*(stok_I0/stok(1,1))
@@ -1072,6 +1354,168 @@ subroutine new_stokes_gmm(lambda,itheta,frac,taille_grain,u0,v0,w0,u1,v1,w1,stok
 
   return
 end subroutine new_stokes_gmm
+
+!***********************************************************
+
+subroutine new_stokes_mueller(lambda,itheta,frac,taille_grain,u0,v0,w0,u1,v1,w1,stok)
+  ! Routine derivee de stokes_gmm pour les matrices de mueller en entrée
+  ! F.Malaval 20/04/2023
+
+  implicit none
+
+  real, intent(in) :: frac
+  real(kind=dp), intent(in) ::  u0,v0,w0,u1,v1,w1
+  integer, intent(in) :: lambda,itheta,taille_grain
+  real(kind=dp), dimension(4), intent(inout) :: stok
+
+  real :: sinw, cosw, omega, theta, costhet,  xnyp, stok_I0, norme, frac_m1
+  real(kind=dp) :: v1pi, v1pj, v1pk
+  integer :: i
+  real(kind=dp), dimension(4,4) :: ROP, RPO, XMUL
+  real(kind=dp), dimension(4) :: C, D
+
+  frac_m1 = 1.0 - frac
+
+!*****
+!     COORDONNEES DES DIFFUSEURS
+!         - X EST VERS L'OBSERVATEUR
+!         - Y ET Z FORME UNE BASE DROITE(DANS LE BON SENS)
+!         - Y VERS LA DROITE ET Z VERS LE HAUT
+!*****
+!
+!--------CALCUL DE L'ANGLE OMEGA ENTRE LE PLAN DE DIFFUSION-------
+!----------ET LE NORD CELESTE PROJETE(COORD. EQUATORIALE)----------
+!
+!         DANS LE SYSTEME DE COORD DE LA NEBULEUSE
+!    VECTEUR 1 (DU POINT "0" AU POINT "1") = (U0,V0,W0)!
+!    VECTEUR 2 (DU POINT "1" AU POINT "2") = (U1,V1,W1)!
+!
+!     ON TRANSFORME POUR QUE V2PRIME = (1,0,0)
+!     L'OBSERV. EST ALORS A +X DANS LE NOUVEAU SYSTEME
+!
+!     TRANSFORMATION POUR V1PRIME
+!
+  call ROTATION(U0,V0,W0,u1,v1,w1,V1PI,V1PJ,V1PK)
+
+!      CALCUL DES ANGLES POUR LA ROTATION
+!
+!  LA NORMALE YPRIME C'EST LE PRODUIT VECTORIEL DE V1PRIME X V2PRIME
+!
+!     YPRIMEI = 0.0
+!     YPRIMEJ = V1PK
+!     YPRIMEK = -V1PJ
+!
+  XNYP = sqrt(V1PK*V1PK + V1PJ*V1PJ)
+  if (XNYP < 1E-10) then
+     XNYP = 0.0
+     COSTHET = 1.0
+  else
+     COSTHET = -1.0*V1PJ / XNYP
+  endif
+!
+! CALCUL DE L'ANGLE ENTRE LA NORMALE ET L'AXE Z (THETA)
+!
+  THETA = acos(COSTHET)
+  if (THETA >= PI) THETA = 0.0
+!
+!     LE PLAN DE DIFFUSION EST A +OU- 90DEG DE LA NORMALE
+!
+  THETA = THETA + 1.570796327
+!
+!----DANS LES MATRICES DE ROTATION L'ANGLE EST OMEGA = 2 * THETA-----
+!
+  OMEGA = 2.0 * THETA
+!
+!     PROCHAIN IF CAR L'ARCCOS VA DE 0 A PI SEULEMENT
+!     LE +/- POUR FAIRE LA DIFFERENCE DANS LE SENS DE ROTATION
+!
+  if (V1PK < 0.0) OMEGA = -1.0 * OMEGA
+!
+! CALCUL DES ELEMENTS DES MATRICES DE ROTATION
+!
+!
+!      RPO = ROTATION DU POINT VERS LE SYSTEME ORIGINAL
+!      ROP = ROTATION DU SYSTEME ORIGINAL VERS LE POINT
+!            (AMENE L'AXE Z DANS LE PLAN DE DIFFUSION)
+!
+  COSW = cos(OMEGA)
+  SINW = sin(OMEGA)
+!
+  if (abs(COSW) < 1E-06) COSW = 0.0
+  if (abs(SINW) < 1E-06) SINW = 0.0
+!
+  RPO(1,1) = 1.0
+  ROP(1,1) = 1.0
+  RPO(1,2) = 0.0
+  ROP(2,1) = 0.0
+  RPO(1,3) = 0.0
+  ROP(3,1) = 0.0
+  RPO(2,1) = 0.0
+  ROP(1,2) = 0.0
+  RPO(2,2) = COSW
+  ROP(2,2) = COSW
+  RPO(2,3) = SINW
+  ROP(3,2) = SINW
+  RPO(3,1) = 0.0
+  ROP(1,3) = 0.0
+  RPO(3,2) = -1.0 * SINW
+  ROP(2,3) = -1.0 * SINW
+  RPO(3,3) = COSW
+  ROP(3,3) = COSW
+  RPO(4,4) = 1.0
+  ROP(4,4) = 1.0
+  RPO(1,4) = 0.0
+  RPO(2,4) = 0.0
+  RPO(3,4) = 0.0
+  RPO(4,1) = 0.0
+  RPO(4,2) = 0.0
+  RPO(4,3) = 0.0
+  ROP(1,4) = 0.0
+  ROP(2,4) = 0.0
+  ROP(3,4) = 0.0
+  ROP(4,1) = 0.0
+  ROP(4,2) = 0.0
+  ROP(4,3) = 0.0
+
+!
+!     MATRICE DE MUELLER
+!     DIFFERENCE DE SIGNE AVEC B&H POUR RESPECTER LA CONVENTION ASTRONOMIQUE
+!             ANGLE = ANTIHORAIRE A PARTIR DU POLE NORD CELESTE
+  xmul(:,:) = tab_mueller(:,:,itheta,taille_grain,lambda) * frac + tab_mueller(:,:,itheta-1,taille_grain,lambda) * frac_m1
+  xmul(4,:) = -xmul(4,:)
+  xmul(:,4) = -xmul(:,4)
+
+
+! -------- CALCUL DE LA POLARISATION ---------
+
+  stok_I0 = stok(1)
+!  STOKE FINAL = RPO * XMUL * ROP * STOKE INITIAL
+  C=matmul(ROP,STOK)
+! LE RESULTAT EST C(4,1)
+
+  D=matmul(XMUL,C)
+! LE RESULTAT EST D(4,1)
+
+  stok=matmul(RPO,D)
+
+! LE RESULTAT EST STOK(4,1): LES PARAMETRES DE
+! STOKES FINAUX
+
+  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
+  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalisé dans mueller2)
+  ! I sortant = I entrant * s11 si diff uniforme
+
+!  norme=tab_albedo(l)*tab_s11(itheta,taille_grain,lambda)*(stok_I0/stok(1,1))
+!  write(*,*) tab_s11(itheta,taille_grain,lambda), stok_I0, stok(1,1)
+  norme=(tab_mueller(1,1,itheta,taille_grain,lambda) * frac + tab_mueller(1,1,itheta-1,taille_grain,lambda) * frac_m1) &
+       * (stok_I0/stok(1))
+  do i=1,4
+     stok(i)=stok(i)*norme
+  enddo
+
+
+  return
+end subroutine new_stokes_mueller
 
 !***********************************************************
 
@@ -1210,8 +1654,8 @@ subroutine new_stokes_pos(lambda,itheta,frac, icell, u0,v0,w0,u1,v1,w1,stok)
   ! LE RESULTAT EST STOK(4,1): LES PARAMETRES DE
   ! STOKES FINAUX
 
-  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entr�
-  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalis� dans mueller2)
+  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
+  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalisé dans mueller2)
   ! I sortant = I entrant * s11 si diff uniforme
 
   !  norme=tab_albedo(l)*tab_s11(l,itheta)*(stok_I0/stok(1,1))
@@ -1227,6 +1671,158 @@ subroutine new_stokes_pos(lambda,itheta,frac, icell, u0,v0,w0,u1,v1,w1,stok)
   return
 
 end subroutine new_stokes_pos
+
+!***********************************************************
+
+subroutine new_stokes_mueller_pos(lambda,itheta,frac, icell, u0,v0,w0,u1,v1,w1,stok)
+  ! Routine derivee de stokes_pos
+  ! F.Malaval 20/04/2023
+
+  implicit none
+
+  real, intent(in) :: frac
+  real(kind=dp), intent(in) ::  u0,v0,w0,u1,v1,w1
+  integer, intent(in) :: lambda, itheta, icell
+  real(kind=dp), dimension(4), intent(inout) :: stok
+
+  real :: sinw, cosw, omega, theta, costhet, xnyp, stok_I0, norme, frac_m1
+  real(kind=dp) :: v1pi, v1pj, v1pk
+  integer :: i
+  real(kind=dp), dimension(4,4) :: ROP, RPO, XMUL
+  real(kind=dp), dimension(4) :: C, D
+
+  frac_m1 = 1.0 - frac
+
+!*****
+!     COORDONNEES DES DIFFUSEURS
+!         - X EST VERS L'OBSERVATEUR
+!         - Y ET Z FORME UNE BASE DROITE(DANS LE BON SENS)
+!         - Y VERS LA DROITE ET Z VERS LE HAUT
+!*****
+!
+!--------CALCUL DE L'ANGLE OMEGA ENTRE LE PLAN DE DIFFUSION-------
+!----------ET LE NORD CELESTE PROJETE(COORD. EQUATORIALE)----------
+!
+!         DANS LE SYSTEME DE COORD DE LA NEBULEUSE
+!    VECTEUR 1 (DU POINT "0" AU POINT "1") = (U0,V0,W0)!
+!    VECTEUR 2 (DU POINT "1" AU POINT "2") = (U1,V1,W1)!
+!
+!     ON TRANSFORME POUR QUE V2PRIME = (1,0,0)
+!     L'OBSERV. EST ALORS A +X DANS LE NOUVEAU SYSTEME
+!
+!     TRANSFORMATION POUR V1PRIME
+  call ROTATION(U0,V0,W0,u1,v1,w1,V1PI,V1PJ,V1PK)
+
+
+!      CALCUL DES ANGLES POUR LA ROTATION
+!
+!  LA NORMALE YPRIME C'EST LE PRODUIT VECTORIEL DE V1PRIME X V2PRIME
+!
+!     YPRIMEI = 0.0
+!     YPRIMEJ = V1PK
+!     YPRIMEK = -V1PJ
+  XNYP = sqrt(V1PK*V1PK + V1PJ*V1PJ)
+  if (XNYP < 1E-10) then
+     XNYP = 0.0
+     COSTHET = 1.0
+  else
+     COSTHET = -1.0*V1PJ / XNYP
+  endif
+
+! CALCUL DE L'ANGLE ENTRE LA NORMALE ET L'AXE Z (THETA)
+  THETA = acos(COSTHET)
+  if (THETA >= PI) THETA = 0.0
+
+!     LE PLAN DE DIFFUSION EST A +OU- 90DEG DE LA NORMALE
+  THETA = THETA + 1.570796327
+
+!----DANS LES MATRICES DE ROTATION L'ANGLE EST OMEGA = 2 * THETA-----
+  OMEGA = 2.0 * THETA
+!     PROCHAIN IF CAR L'ARCCOS VA DE 0 A PI SEULEMENT
+!     LE +/- POUR FAIRE LA DIFFERENCE DANS LE SENS DE ROTATION
+  if (V1PK < 0.0) OMEGA = -1.0 * OMEGA
+
+! CALCUL DES ELEMENTS DES MATRICES DE ROTATION
+!
+!      RPO = ROTATION DU POINT VERS LE SYSTEME ORIGINAL
+!      ROP = ROTATION DU SYSTEME ORIGINAL VERS LE POINT
+!            (AMENE L'AXE Z DANS LE PLAN DE DIFFUSION)
+  COSW = cos(OMEGA)
+  SINW = sin(OMEGA)
+!
+  if (abs(COSW) < 1E-06) COSW = 0.0
+  if (abs(SINW) < 1E-06) SINW = 0.0
+!
+
+  ROP = 0.0
+  RPO = 0.0
+
+  RPO(1,1) = 1.0
+  ROP(1,1) = 1.0
+  RPO(2,2) = COSW
+  ROP(2,2) = COSW
+  RPO(2,3) = SINW
+  ROP(2,3) = -1.0 * SINW
+  RPO(3,2) = -1.0 * SINW
+  ROP(3,2) = SINW
+  RPO(3,3) = COSW
+  ROP(3,3) = COSW
+  RPO(4,4) = 1.0
+  ROP(4,4) = 1.0
+
+!
+!     MATRICE DE MUELLER
+!     DIFFERENCE DE SIGNE AVEC B&H POUR RESPECTER LA CONVENTION ASTRONOMIQUE
+!             ANGLE = ANTIHORAIRE A PARTIR DU POLE NORD CELESTE
+
+  XMUL=0.0
+  XMUL(:,:) = tab_mueller_pos(:,:,itheta,icell,lambda) * frac + tab_mueller_pos(:,:,itheta-1,icell,lambda) * frac_m1
+  XMUL(1,1) = 1.0 ! Comme on a déjà choisi l'angle de diffusion, on met s11=1.0 à chaque angle
+  !! on inverse le signe pour respecter la convention astronomique
+  XMUL(4,:) = -XMUL(4,:)
+  xmul(:,4) = -XMUL(:,4)
+
+  ! -------- CALCUL DE LA POLARISATION ---------
+
+  
+ stok_I0 = stok(1)
+  !  STOKE FINAL = RPO * XMUL * ROP * STOKE INITIAL
+  !  C=matmul(ROP,STOK)
+  C(2:3) = matmul(ROP(2:3,2:3),STOK(2:3))
+  C(1)=stok(1)
+  C(4)=stok(4)
+  ! LE RESULTAT EST C(4,1)
+
+  ! LE RESULTAT EST D(4,1)
+  D=matmul(XMUL,C)
+  ! D(1:2)=matmul(XMUL(1:2,1:2),C(1:2))
+  ! D(3:4)=matmul(XMUL(3:4,3:4),C(3:4))
+
+  !  stok=matmul(RPO,D)
+  stok(2:3)=matmul(RPO(2:3,2:3),D(2:3))
+  stok(1)=D(1)
+  stok(4)=D(4)
+
+  ! LE RESULTAT EST STOK(4,1): LES PARAMETRES DE
+  ! STOKES FINAUX
+
+  ! Normalisation de l'energie : le photon repart avec l'energie avec laquelle il est entré
+  ! I sortant = I entrant si diff selon s11  (tab_s11=1.0 normalisé dans mueller2)
+  ! I sortant = I entrant * s11 si diff uniforme
+
+  !  norme=tab_albedo(l)*tab_s11(l,itheta)*(stok_I0/stok(1,1))
+  if (stok(1) > tiny_real) then
+     norme= XMUL(1,1) * (stok_I0/stok(1))
+     do i=1,4
+        stok(i)=stok(i)*norme
+     enddo
+  else
+     stok(:)=0.0
+  endif
+
+  return
+
+end subroutine new_stokes_mueller_pos
 
 !***********************************************************
 
@@ -1329,11 +1925,11 @@ end subroutine hg
 
 subroutine angle_diff_theta(lambda, taille_grain, aleat, aleat2, itheta, cospsi)
 ! Calcul du cosinus de l'angle de diffusion
-! a partir de l'integrale des s11 pretabul�es
-! itheta est l'indice i de l'angle de 1 a 180 correspondant a i-0.5�
-! cospsi est tire uniform�ment dans le bin de 1� autour de l'angle i-0.5�
-! itheta est utilis� pour les valeurs pr�tabul�es
-! cospsi est utilis� pour la direction de vol
+! a partir de l'integrale des s11 pretabulées
+! itheta est l'indice i de l'angle de 1 a 180 correspondant a i-0.5°
+! cospsi est tire uniformément dans le bin de 1° autour de l'angle i-0.5°
+! itheta est utilisé pour les valeurs prétabulées
+! cospsi est utilisé pour la direction de vol
 ! C. Pinte 23/10/04
 
   implicit none
@@ -1376,8 +1972,8 @@ end subroutine angle_diff_theta
 subroutine angle_diff_theta_pos(lambda, icell, aleat, aleat2, itheta, cospsi)
 ! Calcul du cosinus de l'angle de diffusion
 ! a partir de l'integrale des s11 pretabulee par cellule
-! itheta est l'indice i de l'angle de 1 a 180 correspondant à i-0.5°
-! cospsi est tire uniformément dans le bin de 1° autour de l'angle i-0.5°
+! itheta est l'indice i de l'angle de 1 a 180 correspondant Ã  i-0.5Â°
+! cospsi est tire uniformÃ©ment dans le bin de 1Â° autour de l'angle i-0.5Â°
 ! itheta est utilise pour les valeurs pretabulee
 ! cospsi est utilise pour la direction de vol
 ! C. Pinte 9/01/05
@@ -1421,7 +2017,7 @@ end subroutine angle_diff_theta_pos
 
 subroutine funcd(x,fval,fderiv,ppp,A)
 ! Calcule la fonction de repartition de l'angle de diffusion phi
-! ainsi que sa d�riv�e pour d�terminer le zero par la m�thode des
+! ainsi que sa dérivée pour déterminer le zero par la méthode des
 ! tangentes (Newton)
 ! C. Pinte    23/10/2004
 
@@ -1445,6 +2041,8 @@ subroutine angle_diff_phi(lambda,taille_grain, I, Q, U, itheta, frac, aleat, phi
 ! Uniforme pour une onde non polarisee
 ! Suivant fct de phase de Mie pour un photon polarise
 ! C. Pinte    23/10/2004
+! Ajout du cas ou les matrices de Mueller sont donnees en entrees
+! 20/04/2023
 
   implicit none
 
@@ -1460,20 +2058,25 @@ subroutine angle_diff_phi(lambda,taille_grain, I, Q, U, itheta, frac, aleat, phi
 
 !  write(*,*) 'in',l, itheta, I, Q, U, aleat
 
-  ! Flux polaris� et taux de pola
+  ! Flux polarisé et taux de pola
   Q_dp=Q;U_dp=U
   Ip=sqrt(Q_dp*Q_dp+U_dp*U_dp)
   p=Ip/I
 
   ! polarisabilite
-  pp= (tab_s12(itheta,taille_grain,lambda) * frac + tab_s12(itheta-1,taille_grain,lambda) * frac_m1) &
+  if (lmueller) then
+     pp= (tab_mueller(1,2,itheta,taille_grain,lambda) * frac + tab_mueller(1,2,itheta-1,taille_grain,lambda) * frac_m1) &
+  / (tab_mueller(1,1,itheta,taille_grain,lambda) * frac + tab_mueller(1,1,itheta-1,taille_grain,lambda) * frac_m1)
+  else
+     pp= (tab_s12(itheta,taille_grain,lambda) * frac + tab_s12(itheta-1,taille_grain,lambda) * frac_m1) &
   / (tab_s11(itheta,taille_grain,lambda) * frac + tab_s11(itheta-1,taille_grain,lambda) * frac_m1)
+  endif
 
   ppp=p*pp
 !  write(*,*) p,pp,ppp
 
   if (abs(ppp) > 1.e-3) then
-     ! Mesure de l'angle du plan de pola par rapport au Nord c�leste
+     ! Mesure de l'angle du plan de pola par rapport au Nord céleste
      phi1=0.5*acos(Q_dp/Ip) ! C'est ici qu'on a besoin du dp
      if (U < 0.0) then
         phi1= -phi1
@@ -1497,9 +2100,9 @@ end subroutine angle_diff_phi
 !**********************************************************************
 
 real function rtsafe(funcd,x1,x2,xacc,ppp,A)
-! Trouve le z�ro d'une fonction
-! Ici, l'angle de diffusion en phi pour un photon polaris�
-! suivant la fonction de r�partion donn�e par funcd
+! Trouve le zéro d'une fonction
+! Ici, l'angle de diffusion en phi pour un photon polarisé
+! suivant la fonction de répartion donnée par funcd
 ! C. Pinte    23/10/2004
 
   implicit none


### PR DESCRIPTION
Adds and changes in the code to permit it to read mueller matrices to use in place of Mie calculations. One matrix representing the average matrix over the size distribution can be use as input, or one for each size particle considered in the simulation. For now, this option permit to use the matrices for only 1 considered wavelength.