### PR TITLE
(phantom) fix duplicate symbol errors in phantom+mcfost

### DIFF
--- a/src/SPH2mcfost.f90
+++ b/src/SPH2mcfost.f90
@@ -18,7 +18,7 @@ contains
   subroutine setup_SPH2mcfost(SPH_file,SPH_limits_file, n_SPH, extra_heating)
 
     use read_gadget2, only : read_gadget2_file
-    use dump_utils, only : get_error_text
+    use io_phantom_utils, only : get_error_text
     use utils, only : read_comments
 
     character(len=512), intent(in) :: SPH_file, SPH_limits_file

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -1,7 +1,7 @@
 module read_phantom
 
   use parametres
-  use dump_utils
+  use io_phantom_utils
   use messages
   use constantes
   use mess_up_SPH


### PR DESCRIPTION
this is to fix the following issue when compiling phantom+mcfost:

https://github.com/danieljprice/phantom/issues/341

the relevant files were already renamed but the module files also needed to be renamed. This was flagged as part of the implementation of an automated test for phantom+mcfost cross-compilation via GitHub actions:

https://github.com/danieljprice/phantom/issues/379

and will fix the remaining actions failures on the waiting pull request in the phantom repo:

https://github.com/danieljprice/phantom/pull/412

I have also taken the opportunity to update the phantom utilities modules to their latest versions:
- a few minor bugs were fixed; these should not affect anything inside mcfost
- a new error message was added to print_error_message (this is called by mcfost)
- the updated io_phantom_utils also contains some new routines like print_header and print_arrays_in_file with the same functionality as the showheader and showarrays utilities in phantom which could be useful.