### PR TITLE
Caching dependencies in automated actions builds (macos)

### DIFF
--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -48,8 +48,8 @@ jobs:
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/lib/gfortran
         gfortran --version
 
-    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-      name: install gfortran
+#    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+    - name: install gfortran
       run: brew reinstall gcc
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -82,4 +82,4 @@ jobs:
            MCFOST_GIT: "1"
       run: |
            cd src
-           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib
+           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib -j 2

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,7 +41,9 @@ jobs:
       name: add symbolic links if cache exists
       run: |
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
-        ln -s /usr/local/Cellar/sprng2 /usr/local/sprng2
+        ln -s /usr/local/Cellar/sprng2/2.0/include /usr/local/include
+        brew install tree
+        tree /usr/local/include
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,8 +41,7 @@ jobs:
       name: add symbolic links if cache exists
       run: |
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
-        brew install tree
-        tree /usr/local/Cellar/sprng2/2.0
+        ln -s /usr/local/Cellar/sprng2 /usr/local/sprng2
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,7 +41,7 @@ jobs:
       name: update path if cache exists
       run: |
         export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/"
-        ls /usr/local/
+        ls /usr/local/Cellar/gcc/13.1.0/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,11 +45,11 @@ jobs:
         ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
         which gfortran
         which gfortran-13
-        ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/lib/gfortran
+        ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
         gfortran --version
 
-#    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-    - name: install gfortran
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install gfortran
       run: brew reinstall gcc
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -44,8 +44,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
-        brew install tree
-        tree /usr/local/Cellar/hdf5
+        ln -s /usr/local/Cellar/hdf5/1.14.1/include* /usr/local/include
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -37,6 +37,10 @@ jobs:
           /usr/local/Cellar/sprng2/2.0
         key: ${{ runner.os }}-build-${{ env.cache-name }}
 
+    - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
+      name: update path if cache exists
+      run: export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0"
+
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran
       run: brew reinstall gcc

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -44,6 +44,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
+        ln -s /usr/local/Cellar/voro-dev/0.4.6+/lib/libvoro++* /usr/local/lib
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
         ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
 

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -23,31 +23,43 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: install gfortran
+    - name: cache dependencies
+      id: cache-deps
+      uses: john-shaffer/cache@main     # Needed to add sudo on ubuntu runner - maybe not on macos?
+      env:
+        cache-name: cache-mcfost-dependencies
+      with:
+        path: |
+          /usr/local/Cellar/gcc/13.1.0
+          /usr/local/Cellar/hdf5/1.14.1
+          /usr/local/Cellar/cfitsio/4.3.0
+          /usr/local/Cellar/voro-dev/0.4.6+
+          /usr/local/Cellar/sprng2/2.0
+        key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install gfortran
       run: brew reinstall gcc
 
-    - name: install hdf5
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install hdf5
       run: brew install hdf5
 
-    - name: install cfitsio
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install cfitsio
       run: brew install cfitsio
 
-    - name: get custom taps needed for mcfost
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: get custom taps needed for mcfost
       run: brew tap danieljprice/all
 
-    - name: install voro++
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install voro++
       run: brew install voro-dev
 
-    - name: install sprng2
+    - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      name: install sprng2
       run: brew install sprng2
-
-    - name: get install locations
-      run: |
-        brew info gcc
-        brew info hdf5
-        brew info cfitsio
-        brew info voro-dev
-        brew info sprng2
 
     - name: compile mcfost
       env:

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -43,6 +43,7 @@ jobs:
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
+        ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/voro++/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -82,4 +82,4 @@ jobs:
            MCFOST_GIT: "1"
       run: |
            cd src
-           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib -j 3
+           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,7 +41,8 @@ jobs:
       name: update path if cache exists
       run: |
         export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin/"
-        ls /usr/local/Cellar/gcc/13.1.0/bin/
+        echo $PATH
+        ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -39,7 +39,9 @@ jobs:
 
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
       name: update path if cache exists
-      run: export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0"
+      run: |
+        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/"
+        ls /usr/local/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -82,4 +82,4 @@ jobs:
            MCFOST_GIT: "1"
       run: |
            cd src
-           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib
+           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib -j 3

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,6 +41,14 @@ jobs:
     - name: install sprng2
       run: brew install sprng2
 
+    - name: get install locations
+      run: |
+        brew info gcc
+        brew info hdf5
+        brew info cfitsio
+        brew info voro-dev
+        brew info sprng2
+
     - name: compile mcfost
       env:
            MCFOST_INSTALL: "/usr/local"

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -46,6 +46,7 @@ jobs:
         which gfortran
         which gfortran-13
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/lib/gfortran
+        gfortran --version
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -40,7 +40,7 @@ jobs:
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
       name: update path if cache exists
       run: |
-        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin/"
+        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin"
         echo $PATH
         ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
         which gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -46,6 +46,7 @@ jobs:
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/lib/libvoro++* /usr/local/lib
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
+        ln -s /usr/local/Cellar/hdf5/1.14.1/lib/lib* /usr/local/lib
         ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
 
 

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,6 +45,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         mkdir /usr/local/include/voro++
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/voro++/
+        ls -lsa /usr/local/Cellar/voro-dev/0.4.6+/include/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -43,6 +43,7 @@ jobs:
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
+        mkdir /usr/local/include/voro++
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/voro++/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,9 +45,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
-        ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/cfitsio* /usr/local/lib
-        brew install tree
-        tree /usr/local/Cellar/cfitsio
+        ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,7 +45,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
-        ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/* /usr/local/lib
+        ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/cfitsio* /usr/local/lib
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -38,15 +38,10 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}
 
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
-      name: update path if cache exists
+      name: add symbolic links if cache exists
       run: |
-        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin"
-        echo $PATH
-        ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
-        which gfortran
-        which gfortran-13
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
-        gfortran --version
+        tree /usr/local/Cellar/sprng2/2.0
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: build-gfortran-macos
 
 # Controls when the action will run.
@@ -23,9 +21,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+      # Check if the dependency cache exists
+      # If it does, restore those paths; otherwise these paths are cached at the end of the workflow
+      # NOTE: Cache can be cleared manually from the Github actions webpage
     - name: cache dependencies
       id: cache-deps
-      uses: john-shaffer/cache@main     # Needed to add sudo on ubuntu runner - maybe not on macos?
+      uses: actions/cache@v3
       env:
         cache-name: cache-mcfost-dependencies
       with:
@@ -37,6 +38,8 @@ jobs:
           /usr/local/Cellar/sprng2/2.0
         key: ${{ runner.os }}-build-${{ env.cache-name }}
 
+      # Restoring the brew installs from cache doesn't put files where mcfost expects
+      # Manually create symlinks so the compiler can find everything
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
       name: add symbolic links if cache exists
       run: |
@@ -49,7 +52,7 @@ jobs:
         ln -s /usr/local/Cellar/hdf5/1.14.1/lib/lib* /usr/local/lib
         ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/libcfitsio* /usr/local/lib
 
-
+      # Only do these install steps if no cache is found
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran
       run: brew reinstall gcc
@@ -82,4 +85,4 @@ jobs:
            MCFOST_GIT: "1"
       run: |
            cd src
-           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib -j 2
+           make all INCLUDE=-I/usr/local/include LIBS=/usr/local/lib

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,6 +45,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
+        ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/* /usr/local/lib
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -44,8 +44,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         mkdir /usr/local/include/voro++
-        ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/voro++/
-        ls -lsa /usr/local/Cellar/voro-dev/0.4.6+/include/
+        ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -43,8 +43,7 @@ jobs:
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
-        mkdir /usr/local/include/voro++
-        ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include/
+        ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -44,7 +44,7 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
-        ln -s /usr/local/Cellar/hdf5/1.14.1/include* /usr/local/include
+        ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -46,6 +46,8 @@ jobs:
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
         ln -s /usr/local/Cellar/hdf5/1.14.1/include/* /usr/local/include
         ln -s /usr/local/Cellar/cfitsio/4.3.0/lib/cfitsio* /usr/local/lib
+        brew install tree
+        tree /usr/local/Cellar/cfitsio
 
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -45,6 +45,7 @@ jobs:
         ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
         which gfortran
         which gfortran-13
+        ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/lib/gfortran
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,6 +41,7 @@ jobs:
       name: add symbolic links if cache exists
       run: |
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
+        brew install tree
         tree /usr/local/Cellar/sprng2/2.0
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -41,9 +41,8 @@ jobs:
       name: add symbolic links if cache exists
       run: |
         ln -s /usr/local/Cellar/gcc/13.1.0/bin/gfortran /usr/local/bin/gfortran
-        ln -s /usr/local/Cellar/sprng2/2.0/include /usr/local/include
-        brew install tree
-        tree /usr/local/include
+        ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
+        ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -40,8 +40,8 @@ jobs:
     - if: ${{ steps.cache-deps.outputs.cache-hit == 'true' }}
       name: update path if cache exists
       run: |
-        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/"
-        ls /usr/local/Cellar/gcc/13.1.0/
+        export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin/"
+        ls /usr/local/Cellar/gcc/13.1.0/bin/
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -43,6 +43,8 @@ jobs:
         export PATH="$PATH:/usr/local/Cellar/gcc/13.1.0/bin/"
         echo $PATH
         ls -lsa /usr/local/Cellar/gcc/13.1.0/bin/
+        which gfortran
+        which gfortran-13
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran

--- a/.github/workflows/build-gfortran-macos.yml
+++ b/.github/workflows/build-gfortran-macos.yml
@@ -44,6 +44,9 @@ jobs:
         ln -s /usr/local/Cellar/sprng2/2.0/include/* /usr/local/include
         ln -s /usr/local/Cellar/sprng2/2.0/lib/* /usr/local/lib
         ln -s /usr/local/Cellar/voro-dev/0.4.6+/include/* /usr/local/include
+        brew install tree
+        tree /usr/local/Cellar/hdf5
+
 
     - if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
       name: install gfortran


### PR DESCRIPTION
Dependencies for mcfost (e.g. hdf5, voro++) are stored using Github actions caching feature which avoids the need to re-download/install each time the build workflow is run. This should speed up the build test (by a minute or two in my testing). The cache is automatically cleared by Github every 7 days.