### PR TITLE
Support for intel compilers in automated build tests

### DIFF
--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -11,21 +11,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # Cache dependencies for mcfost to avoid downloading/installing them each time this workflow runs
-    - name: cache dependencies
-      id: cache-deps
-      uses: actions/cache@v3
-      with:
-        path: ${{ env.MCFOST_INSTALL }}
-        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
-
-    # Only do this (lengthy) setup if dependency cache not found
-    - name: prepare mcfost environment
-      if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
-      shell: bash
-      working-directory: lib
-      run: |
-        ./install.sh
 
     # hdf5.mod file is located at /usr/lib64/gfortran/modules/ on almalinux
     - name: install hdf5 for gnu build
@@ -56,3 +41,19 @@ runs:
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
         echo "Done"
+
+    # Cache other dependencies for mcfost to avoid downloading/installing them each time this workflow runs
+    - name: cache dependencies
+      id: cache-deps
+      uses: actions/cache@v3
+      with:
+        path: ${{ env.MCFOST_INSTALL }}
+        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
+
+    # Only do this (lengthy) setup if dependency cache not found
+    - name: prepare mcfost environment
+      if: ${{ steps.cache-deps.outputs.cache-hit != 'true' }}
+      shell: bash
+      working-directory: lib
+      run: |
+        ./install.sh

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -39,6 +39,8 @@ runs:
         mkdir /usr/include/hdf5
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+        apt-get update
+        apt-get install zlib1g-dev -y
 
     # Cache other dependencies for mcfost to avoid downloading/installing them each time this workflow runs
     - name: cache dependencies
@@ -54,5 +56,4 @@ runs:
       shell: bash
       working-directory: lib
       run: |
-        cp /lib/x86_64-linux-gnu/libz* /usr/lib/
         ./install.sh

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -13,7 +13,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MCFOST_INSTALL }}
-        key: mcfost-deps-${{ runner.os }}-${{ hashFiles('lib/install.sh') }}
+        key: TESTmcfost-deps-${{ runner.os }}-${{ hashFiles('lib/install.sh') }}
 
     # Only do this (lengthy) setup if dependency cache not found
     - name: prepare mcfost environment

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -1,5 +1,9 @@
 name: "linux"
 description: "linux dependencies"
+inputs:
+  compiler:
+    description: Which compiler to use (gnu or intel?)
+    required: true
 
 # Note: needs GCC > 12, and sudo, wherever you're building
 # Using gcc-11 will return a bug when compiling gas/wavelengths_gas.f90
@@ -13,7 +17,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MCFOST_INSTALL }}
-        key: TESTmcfost-deps-${{ runner.os }}-${{ hashFiles('lib/install.sh') }}
+        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
 
     # Only do this (lengthy) setup if dependency cache not found
     - name: prepare mcfost environment
@@ -22,3 +26,31 @@ runs:
       working-directory: lib
       run: |
         ./install.sh
+
+    # hdf5.mod file is located at /usr/lib64/gfortran/modules/ on almalinux
+    - name: install hdf5 for gnu build
+      if: ${{ matrix.toolchain.compiler == 'gfortran' }}
+      run: |
+        dnf install -y sudo wget epel-release
+        dnf install -y hdf5-static redhat-lsb-core
+        cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
+
+    - name: install hdf5 for intel build
+      if: ${{ matrix.toolchain.compiler == 'ifort' }}
+      run: |
+        export CC=icc
+        export FC=ifort
+        export CXX=icpc
+        export CFLAGS=""
+        wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
+        echo "Compiling HDF5 ..."
+        tar xjvf hdf5-1.10.5.tar.bz2
+        cd hdf5-1.10.5
+        mkdir -p "$HOME/hdf5_install_tmp"
+        ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
+        make install
+        \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+        mkdir /usr/include/hdf5
+        \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+        \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+        echo "Done"

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -29,14 +29,9 @@ runs:
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
-        mkdir -p "$HOME/hdf5_install_tmp"
-        ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
+        ./configure --prefix="/usr/local" --enable-fortran --disable-shared
         make install
-        \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
-        mkdir /usr/include/hdf5
-        \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-        \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
-    
+
     - name: get zlib dev libraries
       if: ${{ matrix.toolchain.compiler == 'ifort' }}
       shell: bash

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -39,7 +39,7 @@ runs:
         mkdir /usr/include/hdf5
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
-        sudo apt install zlib1g -y
+        apt install zlib1g -y
 
     # Cache other dependencies for mcfost to avoid downloading/installing them each time this workflow runs
     - name: cache dependencies

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -55,4 +55,5 @@ runs:
       shell: bash
       working-directory: lib
       run: |
+        export LD_LIBRARY_PATH=LD_LIBRARY_PATH:/lib/x86_64-linux-gnu/
         ./install.sh

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -50,7 +50,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MCFOST_INSTALL }}
-        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}-${{ hashFiles('lib/install.sh') }}
 
     # Only do this (lengthy) setup if dependency cache not found
     - name: prepare mcfost environment

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -39,7 +39,6 @@ runs:
         mkdir /usr/include/hdf5
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
-        apt install zlib1g -y
 
     # Cache other dependencies for mcfost to avoid downloading/installing them each time this workflow runs
     - name: cache dependencies
@@ -55,5 +54,5 @@ runs:
       shell: bash
       working-directory: lib
       run: |
-        export LD_LIBRARY_PATH=LD_LIBRARY_PATH:/lib/x86_64-linux-gnu/
+        cp /lib/x86_64-linux-gnu/libz* /usr/lib/
         ./install.sh

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -30,7 +30,6 @@ runs:
         export CXX=icpc
         export CFLAGS=""
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
-        echo "Compiling HDF5 ..."
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
         mkdir -p "$HOME/hdf5_install_tmp"
@@ -40,7 +39,7 @@ runs:
         mkdir /usr/include/hdf5
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
-        echo "Done"
+        sudo apt install zlib1g -y
 
     # Cache other dependencies for mcfost to avoid downloading/installing them each time this workflow runs
     - name: cache dependencies

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -17,7 +17,7 @@ runs:
         dnf install -y hdf5-static redhat-lsb-core
         cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
 
-    # hdf5 needs to be built from sources.
+    # hdf5 needs to be built from sources for intel compilers
     - name: install hdf5 for intel build
       if: ${{ matrix.toolchain.compiler == 'ifort' }}
       shell: bash

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -1,9 +1,5 @@
 name: "linux"
 description: "linux dependencies"
-inputs:
-  compiler:
-    description: Which compiler to use (gnu or intel?)
-    required: true
 
 # Note: needs GCC > 12, and sudo, wherever you're building
 # Using gcc-11 will return a bug when compiling gas/wavelengths_gas.f90
@@ -21,6 +17,7 @@ runs:
         dnf install -y hdf5-static redhat-lsb-core
         cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
 
+    # hdf5 needs to be built from sources.
     - name: install hdf5 for intel build
       if: ${{ matrix.toolchain.compiler == 'ifort' }}
       shell: bash
@@ -39,6 +36,11 @@ runs:
         mkdir /usr/include/hdf5
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+    
+    - name: get zlib dev libraries
+      if: ${{ matrix.toolchain.compiler == 'ifort' }}
+      shell: bash
+      run: |
         apt-get update
         apt-get install zlib1g-dev -y
 
@@ -48,7 +50,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MCFOST_INSTALL }}
-        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}
 
     # Only do this (lengthy) setup if dependency cache not found
     - name: prepare mcfost environment

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -21,11 +21,12 @@ runs:
     - name: install hdf5 for intel build
       if: ${{ matrix.toolchain.compiler == 'ifort' }}
       shell: bash
+      env:
+        CC: icc
+        FC: ifort
+        CXX: icpc
+        CFLAGS: ""
       run: |
-        export CC=icc
-        export FC=ifort
-        export CXX=icpc
-        export CFLAGS=""
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5

--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -30,6 +30,7 @@ runs:
     # hdf5.mod file is located at /usr/lib64/gfortran/modules/ on almalinux
     - name: install hdf5 for gnu build
       if: ${{ matrix.toolchain.compiler == 'gfortran' }}
+      shell: bash
       run: |
         dnf install -y sudo wget epel-release
         dnf install -y hdf5-static redhat-lsb-core
@@ -37,6 +38,7 @@ runs:
 
     - name: install hdf5 for intel build
       if: ${{ matrix.toolchain.compiler == 'ifort' }}
+      shell: bash
       run: |
         export CC=icc
         export FC=ifort

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -78,8 +78,8 @@ runs:
         mkdir -p "$HOME/hdf5_install_tmp"
         ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
         make install
-        \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+        sudo cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
         mkdir /usr/include/hdf5
-        \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-        \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+        sudo cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+        sudo cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
         echo "Done" 

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: install intel compilers
-      if: ${{ inputs.compiler == 'ifort' }}
+      if: ${{ matrix.compiler == 'ifort' }}
       shell: bash
       run: |
         sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
@@ -28,7 +28,7 @@ runs:
           /usr/local/Cellar/cfitsio/
           /usr/local/Cellar/voro-dev/
           /usr/local/Cellar/sprng2/
-        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.compiler }}
 
       # Symlinks to the path need to be created again after the cache is restored
     - name: add brew links
@@ -52,14 +52,14 @@ runs:
 
     # Always install hdf5, it's too problematic to cache (because it has dependencies)
     - name: install hdf5 (gfortran)
-      if: ${{ inputs.compiler == 'gfortran' }}
+      if: ${{ matrix.compiler == 'gfortran' }}
       shell: bash
       run: |
         brew install hdf5
 
     # Brew installs the gcc version. Intel requires some more work
     - name: install hdf5 (ifort)
-      if: ${{ inputs.compiler == 'ifort' }}
+      if: ${{ matrix.compiler == 'ifort' }}
       shell: bash
       run: |
           export CFLAGS=""

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: install intel compilers
-      if: ${{ input.compiler == 'ifort' }}
+      if: ${{ inputs.compiler == 'ifort' }}
       shell: bash
       run: |
         sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -8,6 +8,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: install intel compilers
+        if: ${{ input.compiler == 'ifort' }}
+        run: |
+          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+          hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+          hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+          sudo /Volumes/m_cpp-compiler-classic_p_2023.2.0.48999_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+          cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
+    
     # Check if the dependency cache exists
     # If it does, restore those paths; otherwise these paths are cached at the end of the workflow
     # NOTE: Cache can be cleared manually from the Github actions webpage
@@ -58,6 +69,7 @@ runs:
         export FC=ifort
         export CXX=icpc
         export CFLAGS=""
+        source /opt/intel/oneapi/setvars.sh 
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
         echo "Compiling HDF5 ..."
         tar xjvf hdf5-1.10.5.tar.bz2

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -1,9 +1,5 @@
 name: "macos"
 description: "macos dependencies"
-inputs:
-  compiler:
-    description: Which compiler to use (gnu or intel?)
-    required: true
 
 runs:
   using: "composite"
@@ -66,20 +62,12 @@ runs:
       if: ${{ inputs.compiler == 'ifort' }}
       shell: bash
       run: |
-        export CC=icc
-        export FC=ifort
-        export CXX=icpc
-        export CFLAGS=""
-        source /opt/intel/oneapi/setvars.sh 
-        wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
-        tar xjvf hdf5-1.10.5.tar.bz2
-        cd hdf5-1.10.5
-        ls -lsh /usr
-        sudo mkdir /usr/hdf5_install_tmp
-        ./configure --prefix=/usr/hdf5_install_tmp --enable-fortran --disable-shared
-        make install
-        sudo cp /usr/hdf5_install_tmp/lib/libhdf5.a /usr/hdf5_install_tmp/lib/libhdf5_fortran.a /usr/lib/
-        sudo mkdir /usr/include/hdf5
-        sudo cp /usr/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-        sudo cp /usr/hdf5_install_tmp/include/*.mod /usr/include/
-        echo "Done" 
+          export CFLAGS=""
+          source /opt/intel/oneapi/setvars.sh 
+          wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
+          tar xjvf hdf5-1.10.5.tar.bz2
+          cd hdf5-1.10.5
+          sudo CC=icc FC=ifort CXX=icpc ./configure --prefix=/usr/local --enable-fortran  --enable-cxx
+          sudo make
+          sudo make install
+

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -75,11 +75,11 @@ runs:
         echo "Compiling HDF5 ..."
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
-        mkdir -p "$HOME/hdf5_install_tmp"
-        ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
+        mkdir /usr/hdf5_install_tmp
+        ./configure --prefix=/usr/hdf5_install_tmp --enable-fortran --disable-shared
         make install
-        sudo cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+        cp /usr/hdf5_install_tmp/lib/libhdf5.a /usr/hdf5_install_tmp/lib/libhdf5_fortran.a /usr/lib/
         mkdir /usr/include/hdf5
-        sudo cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-        sudo cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+        cp /usr/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+        cp /usr/hdf5_install_tmp/include/*.mod /usr/include/
         echo "Done" 

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -8,8 +8,8 @@ runs:
       if: ${{ matrix.compiler == 'ifort' }}
       shell: bash
       run: |
-        sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-        sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+        wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+        wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
         hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
         sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
         hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -1,5 +1,9 @@
 name: "macos"
 description: "macos dependencies"
+inputs:
+  compiler:
+    description: Which compiler to use (gnu or intel?)
+    required: true
 
 runs:
   using: "composite"
@@ -16,7 +20,7 @@ runs:
           /usr/local/Cellar/cfitsio/
           /usr/local/Cellar/voro-dev/
           /usr/local/Cellar/sprng2/
-        key: TESTmcfost-deps-${{ runner.os }}
+        key: mcfost-deps-${{ runner.os }}-${{ inputs.compiler }}
 
       # Symlinks to the path need to be created again after the cache is restored
     - name: add brew links
@@ -39,7 +43,15 @@ runs:
         brew install cfitsio voro-dev sprng2
 
     # Always install hdf5, it's too problematic to cache (because it has dependencies)
-    - name: install hdf5
+    - name: install hdf5 (gfortran)
+      if: ${{ inputs.compiler == 'gfortran' }}
+      shell: bash
+      run: |
+        brew install hdf5
+
+    # Brew installs the gcc version. Intel requires some more work
+    - name: install hdf5 (ifort)
+      if: ${{ inputs.compiler == 'ifort' }}
       shell: bash
       run: |
         export CC=icc
@@ -58,4 +70,3 @@ runs:
         \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
         \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
         echo "Done" 
-      # brew install hdf5

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -75,11 +75,12 @@ runs:
         echo "Compiling HDF5 ..."
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
-        mkdir /usr/hdf5_install_tmp
+        ls -lsh /usr
+        sudo mkdir /usr/hdf5_install_tmp
         ./configure --prefix=/usr/hdf5_install_tmp --enable-fortran --disable-shared
         make install
-        cp /usr/hdf5_install_tmp/lib/libhdf5.a /usr/hdf5_install_tmp/lib/libhdf5_fortran.a /usr/lib/
-        mkdir /usr/include/hdf5
-        cp /usr/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-        cp /usr/hdf5_install_tmp/include/*.mod /usr/include/
+        sudo cp /usr/hdf5_install_tmp/lib/libhdf5.a /usr/hdf5_install_tmp/lib/libhdf5_fortran.a /usr/lib/
+        sudo mkdir /usr/include/hdf5
+        sudo cp /usr/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+        sudo cp /usr/hdf5_install_tmp/include/*.mod /usr/include/
         echo "Done" 

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -16,7 +16,7 @@ runs:
           /usr/local/Cellar/cfitsio/
           /usr/local/Cellar/voro-dev/
           /usr/local/Cellar/sprng2/
-        key: mcfost-deps-${{ runner.os }}
+        key: TESTmcfost-deps-${{ runner.os }}
 
       # Symlinks to the path need to be created again after the cache is restored
     - name: add brew links
@@ -41,4 +41,21 @@ runs:
     # Always install hdf5, it's too problematic to cache (because it has dependencies)
     - name: install hdf5
       shell: bash
-      run:  brew install hdf5
+      run: |
+        export CC=icc
+        export FC=ifort
+        export CXX=icpc
+        export CFLAGS=""
+        wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
+        echo "Compiling HDF5 ..."
+        tar xjvf hdf5-1.10.5.tar.bz2
+        cd hdf5-1.10.5
+        mkdir -p "$HOME/hdf5_install_tmp"
+        ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
+        make install
+        \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+        mkdir /usr/include/hdf5
+        \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+        \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
+        echo "Done" 
+      # brew install hdf5

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -72,7 +72,6 @@ runs:
         export CFLAGS=""
         source /opt/intel/oneapi/setvars.sh 
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
-        echo "Compiling HDF5 ..."
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
         ls -lsh /usr

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -9,15 +9,16 @@ runs:
   using: "composite"
   steps:
     - name: install intel compilers
-        if: ${{ input.compiler == 'ifort' }}
-        run: |
-          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
-          hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
-          sudo /Volumes/m_cpp-compiler-classic_p_2023.2.0.48999_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
+      if: ${{ input.compiler == 'ifort' }}
+      shell: bash
+      run: |
+        sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+        sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+        hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+        sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+        hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+        sudo /Volumes/m_cpp-compiler-classic_p_2023.2.0.48999_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+        cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
     
     # Check if the dependency cache exists
     # If it does, restore those paths; otherwise these paths are cached at the end of the workflow

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -28,7 +28,7 @@ runs:
           /usr/local/Cellar/cfitsio/
           /usr/local/Cellar/voro-dev/
           /usr/local/Cellar/sprng2/
-        key: mcfost-deps-${{ runner.os }}-${{ matrix.compiler }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}-${{ hashFiles('lib/install.sh') }}
 
       # Symlinks to the path need to be created again after the cache is restored
     - name: add brew links

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,7 +40,7 @@ runs:
         export PATH=/opt/python/cp311-cp311/bin/:$PATH
         cd test_suite
         echo checkpoint1
-        pip --version
+        python -m pip --version
         echo checkpoint2
-        pip install -r requirements.txt
+        python -m pip install -r requirements.txt
         python -m pytest -v

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,7 +39,8 @@ runs:
         export MCFOST_UTILS=$PWD/utils
         export PATH=/opt/python/cp311-cp311/bin/:$PATH
         cd test_suite
+        echo checkpoint1
+        pip --version
+        echo checkpoint2
         pip install -r requirements.txt
-        echo here
-        python --version
         python -m pytest -v

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -40,4 +40,6 @@ runs:
         export PATH=/opt/python/cp311-cp311/bin/:$PATH
         cd test_suite
         pip install -r requirements.txt
+        echo here
+        python --version
         python -m pytest -v

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,8 +39,5 @@ runs:
         export MCFOST_UTILS=$PWD/utils
         export PATH=/opt/python/cp311-cp311/bin/:$PATH
         cd test_suite
-        echo checkpoint1
-        python -m pip --version
-        echo checkpoint2
         python -m pip install -r requirements.txt
         python -m pytest -v

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -67,6 +67,7 @@ jobs:
       - run: git config --global --add safe.directory $PWD
 
       - name: zlib check
+        if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           apt-get install zlib1g -y
           which zlib

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,8 +69,9 @@ jobs:
       - name: install hdf5 for intel build
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          apt search hdf5
-          apt install -y libhdf5-dev
+          add-apt-repository universe
+          apt-get update
+          apt-get install libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -34,7 +34,7 @@ jobs:
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          cp $(find /opt/intel/oneapi/compiler/ | grep "ifort$") /usr/local/include
+          cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
           source /opt/intel/oneapi/setvars.sh 
           echo "Do we have ifort?"
           which ifort
@@ -47,7 +47,10 @@ jobs:
 
       - name: compile mcfost
         working-directory: src
-        run: make all
+        run: |
+          which ifort
+          source /opt/intel/oneapi/setvars.sh
+          make all
 
       - name: test
         uses: ./.github/actions/test
@@ -90,9 +93,9 @@ jobs:
           mkdir -p "$HOME/hdf5_install_tmp"
           ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
           make install
-          \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" lib/
-          \cp "$HOME"/hdf5_install_tmp/include/*.h include/hdf5/
-          \cp "$HOME"/hdf5_install_tmp/include/*.mod "include/$SYSTEM"
+          \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+          \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
+          \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
           echo "Done"
 
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -74,6 +74,7 @@ jobs:
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           python --version
+          python -m ensurepip --upgrade
           pip --version
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,6 +28,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: install intel compilers
+        if: ${{ matrix.compiler == 'ifort' }}
+        run:
+          sudo ./install.sh --silent --eula accept
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
@@ -65,7 +69,7 @@ jobs:
       - name: install hdf5 for intel build
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          apt install -y libhdf5-dev
+          apt-get install -y libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -12,6 +12,7 @@ on:
 env:
   MCFOST_NO_XGBOOST: yes
   MCFOST_GIT: "1"
+  SKIP_HDF5: yes
 
 jobs:
   macos:
@@ -24,7 +25,6 @@ jobs:
       SYSTEM: ${{ matrix.compiler }}
       HDF5_DIR: /usr/local
       MCFOST_INSTALL: /usr/local
-      SKIP_HDF5: yes
     steps:
       - uses: actions/checkout@v2
 
@@ -42,8 +42,8 @@ jobs:
     strategy:
       matrix:
         toolchain: 
-          - {compiler: gfortran, container: quay.io/pypa/manylinux_2_28_x86_64, skiphdf5: 'yes'}
-          - {compiler: ifort, container: "intel/oneapi-hpckit:2023.2-devel-ubuntu22.04", skiphdf5: 'no'}
+          - {compiler: gfortran, container: quay.io/pypa/manylinux_2_28_x86_64}
+          - {compiler: ifort, container: "intel/oneapi-hpckit:2023.2-devel-ubuntu22.04"}
     
     runs-on: ubuntu-22.04
     container: ${{ matrix.toolchain.container }}
@@ -51,7 +51,6 @@ jobs:
       SYSTEM: ${{ matrix.toolchain.compiler }}
       HDF5_DIR: /usr
       MCFOST_INSTALL: /opt/local
-      SKIP_HDF5: ${{ matrix.toolchain.skiphdf5 }}
     steps:
       - uses: actions/checkout@v2
 
@@ -62,6 +61,11 @@ jobs:
           dnf install -y sudo wget epel-release
           dnf install -y hdf5-static redhat-lsb-core
           cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
+
+      - name: install hdf5 for intel build
+        if: ${{ matrix.toolchain.compiler == 'ifort' }}
+        run: |
+          sudo apt install -y libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -68,8 +68,6 @@ jobs:
 
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux
-        with:
-          compiler: ${{ matrix.toolchain.compiler }}
 
       - name: compile mcfost
         working-directory: src

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,6 +37,8 @@ jobs:
           tree /Volumes
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
           cp $(find /opt/intel/oneapi/compiler/ | grep "ifort$") /usr/local/include
+          echo "Do we have ifort?"
+          which ifort
           
           
         #cp $(find /opt/intel/oneapi/compiler/ | grep "icc$") /usr/local/include
@@ -78,13 +80,22 @@ jobs:
       - name: install hdf5 for intel build
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          add-apt-repository universe
-          apt-get update
-          apt-get install -y libhdf5-dev
-          dpkg -L libhdf5-dev
-          cp "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a" "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_fortran.a" /usr/lib/
-          cp /usr/include/hdf5/serial/*.h /usr/include/hdf5/
-          cp /usr/include/hdf5/serial/*.mod /usr/include/
+          export CC=icc
+          export FC=ifort
+          export CXX=icpc
+          export CFLAGS=""
+          wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
+          echo "Compiling HDF5 ..."
+          tar xjvf hdf5-1.10.5.tar.bz2
+          cd hdf5-1.10.5
+          mkdir -p "$HOME/hdf5_install_tmp"
+          ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
+          make install
+          cd ~1
+          \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" lib/
+          \cp "$HOME"/hdf5_install_tmp/include/*.h include/hdf5/
+          \cp "$HOME"/hdf5_install_tmp/include/*.mod "include/$SYSTEM"
+          echo "Done"
           
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           apt-get install zlib1g -y
-          which zlib
+          dpkg -L zlib1g
 
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -81,7 +81,7 @@ jobs:
           tar xzvf cfitsio-4.3.0.tar.gz
           mv cfitsio-4.3.0 cfitsio
           cd cfitsio
-          export LDFLAGS = /lib/x86_64-linux-gnu
+          export LDFLAGS=/lib/x86_64-linux-gnu
           ./configure --enable-ssse3 --disable-curl
           
           make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,21 +64,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: setup python
-        if: ${{ matrix.toolchain.compiler == 'ifort' }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: check python and pip
-        if: ${{ matrix.toolchain.compiler == 'ifort' }}
-        run: |
-          python --version
-          apt-get update
-          apt-get install python3-pip -y
-          pip --version
-          which pip
-
       - run: git config --global --add safe.directory $PWD
 
       - name: build and install dependencies

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -72,6 +72,21 @@ jobs:
           apt-get install zlib1g -y
           dpkg -L zlib1g
 
+      - name: cfitsio test
+        if: ${{ matrix.toolchain.compiler == 'ifort' }}
+        run: |
+          wget -N http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.3.0.tar.gz
+          echo "Compiling CFITSIO ..."
+          tar xzvf cfitsio-4.3.0.tar.gz
+          mv cfitsio-4.3.0 cfitsio
+          cd cfitsio
+          ./configure --enable-ssse3 --disable-curl
+          
+          make
+          \cp libcfitsio.a ../lib
+          cd ~1
+          echo "Done"
+
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,7 +69,8 @@ jobs:
       - name: install hdf5 for intel build
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          apt-get install -y libhdf5-dev
+          apt search hdf5
+          apt install -y libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -74,7 +74,7 @@ jobs:
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           python --version
-          python -m ensurepip --upgrade
+          apt-get install python3-pip
           pip --version
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,6 +69,7 @@ jobs:
       - name: zlib check
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
+          apt-get update
           apt-get install zlib1g-dev -y
           dpkg -L zlib1g-dev
           echo "char inflateEnd ();" >> ctest.c

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
-        with:
-          compiler: ${{ matrix.compiler }}
 
       - name: compile mcfost
         if: ${{ matrix.compiler == 'gfortran' }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -77,7 +77,7 @@ jobs:
           echo "       return inflateEnd ();" >> ctest.c
           echo "}" >> ctest.c
           cat ctest.c
-          gcc ctest.c -o testcompile -lz
+          gcc ctest.c -o testcompile -lz -L/lib/x86_64-linux-gnu
 
       - name: cfitsio test
         if: ${{ matrix.toolchain.compiler == 'ifort' }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -67,7 +67,9 @@ jobs:
       - run: git config --global --add safe.directory $PWD
 
       - name: zlib check
-        run: which zlib
+        run: |
+          apt install zlib1g -y
+          which zlib
 
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,15 +69,15 @@ jobs:
       - name: zlib check
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          apt-get install zlib1g -y
-          dpkg -L zlib1g
+          apt-get install zlib1g-dev -y
+          dpkg -L zlib1g-dev
           echo "char inflateEnd ();" >> ctest.c
           echo "int main (void)" >> ctest.c
           echo "{" >> ctest.c
           echo "       return inflateEnd ();" >> ctest.c
           echo "}" >> ctest.c
           cat ctest.c
-          gcc ctest.c -o testcompile -lz -L/lib/x86_64-linux-gnu
+          gcc ctest.c -o testcompile -lz
 
       - name: cfitsio test
         if: ${{ matrix.toolchain.compiler == 'ifort' }}

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           apt-get install zlib1g -y
           dpkg -L zlib1g
+          echo $LDFLAGS
 
       - name: cfitsio test
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
@@ -80,6 +81,7 @@ jobs:
           tar xzvf cfitsio-4.3.0.tar.gz
           mv cfitsio-4.3.0 cfitsio
           cd cfitsio
+          export LDFLAGS = /lib/x86_64-linux-gnu
           ./configure --enable-ssse3 --disable-curl
           
           make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,7 +65,7 @@ jobs:
       - name: install hdf5 for intel build
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
-          sudo apt install -y libhdf5-dev
+          apt install -y libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: setup python
         uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
 
       - name: check python and pip
         run: |

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: install intel compilers
         if: ${{ matrix.compiler == 'ifort' }}
-        run:
+        run: |
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           ls /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: zlib check
         run: |
-          apt install zlib1g -y
+          apt-get install zlib1g -y
           which zlib
 
       - name: build and install dependencies

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -75,7 +75,7 @@ jobs:
         run: |
           python --version
           apt-get update
-          apt-get install python3-pip
+          apt-get install python3-pip -y
           pip --version
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,7 @@ jobs:
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
-      - name: compile mcfost
+      - name: compile mcfost (gnu)
         if: ${{ matrix.compiler == 'gfortran' }}
         working-directory: src
         run: make all

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,6 +35,7 @@ jobs:
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
           cp $(find /opt/intel/oneapi/compiler/ | grep "ifort$") /usr/local/include
+          source /opt/intel/oneapi/setvars.sh 
           echo "Do we have ifort?"
           which ifort
 
@@ -89,7 +90,6 @@ jobs:
           mkdir -p "$HOME/hdf5_install_tmp"
           ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
           make install
-          cd ~1
           \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" lib/
           \cp "$HOME"/hdf5_install_tmp/include/*.h include/hdf5/
           \cp "$HOME"/hdf5_install_tmp/include/*.mod "include/$SYSTEM"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -51,7 +51,6 @@ jobs:
         if: ${{ matrix.compiler == 'ifort' }}
         working-directory: src
         run: |
-          which ifort
           source /opt/intel/oneapi/setvars.sh 
           make all
 
@@ -97,6 +96,7 @@ jobs:
           ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
           make install
           \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
+          mkdir /usr/include/hdf5
           \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
           \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
           echo "Done"

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -35,7 +35,7 @@ jobs:
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           tree /Volumes
-          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/install.sh --silent --eula accept
+          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
           hdiutil detach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
@@ -77,9 +77,10 @@ jobs:
           add-apt-repository universe
           apt-get update
           apt-get install -y libhdf5-dev
+          dpkg -L libhdf5-dev
           cp "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a" "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_fortran.a" /usr/lib/
-          cp "/usr/include/hdf5/serial/*.h" /usr/include/hdf5/
-          cp "/usr/include/hdf5/serial/*.mod" /usr/include/
+          cp "/home/runner/work/include/hdf5/serial/*.h" /usr/include/hdf5/
+          cp "/home/runner/work/include/hdf5/serial/*.mod" /usr/include/
           
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -77,6 +77,7 @@ jobs:
           apt-get update
           apt-get install python3-pip -y
           pip --version
+          which pip
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,8 +64,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: check python
-        run: python --version
+      - name: setup python
+        uses: actions/setup-python@v4
+
+      - name: check python and pip
+        run: |
+          python --version
+          pip --version
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -32,12 +32,12 @@ jobs:
         if: ${{ matrix.compiler == 'ifort' }}
         run: |
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+          hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
+          sudo /Volumes/m_cpp-compiler-classic_p_2023.2.0.48999_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
           cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
-          source /opt/intel/oneapi/setvars.sh 
-          echo "Do we have ifort?"
-          which ifort
 
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,6 +36,11 @@ jobs:
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           tree /Volumes
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
+          cp $(find /opt/intel/oneapi/compiler/ | grep "ifort$") /usr/local/include
+          
+          
+        #cp $(find /opt/intel/oneapi/compiler/ | grep "icc$") /usr/local/include
+
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
@@ -78,8 +83,8 @@ jobs:
           apt-get install -y libhdf5-dev
           dpkg -L libhdf5-dev
           cp "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a" "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_fortran.a" /usr/lib/
-          cp "/usr/include/hdf5/serial/*.h" /usr/include/hdf5/
-          cp "/usr/include/hdf5/serial/*.mod" /usr/include/
+          cp /usr/include/hdf5/serial/*.h /usr/include/hdf5/
+          cp /usr/include/hdf5/serial/*.mod /usr/include/
           
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,11 +65,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: setup python
+        if: ${{ matrix.toolchain.compiler == 'ifort' }}
         uses: actions/setup-python@v4
         with:
           python-version: "3.11"
 
       - name: check python and pip
+        if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           python --version
           pip --version

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,7 +71,12 @@ jobs:
         run: |
           apt-get install zlib1g -y
           dpkg -L zlib1g
-          echo $LDFLAGS
+          echo char inflateEnd (); >> ctest.c
+          echo int main (void) >> ctest.c
+          echo { >> ctest.c
+          echo        return inflateEnd (); >> ctest.c
+          echo } >> ctest.c
+          gcc ctest.c -o testcompile -lz
 
       - name: cfitsio test
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
@@ -81,7 +86,6 @@ jobs:
           tar xzvf cfitsio-4.3.0.tar.gz
           mv cfitsio-4.3.0 cfitsio
           cd cfitsio
-          export LDFLAGS=/lib/x86_64-linux-gnu
           ./configure --enable-ssse3 --disable-curl
           
           make

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
+        with:
+          compiler: ${{ matrix.compiler }}
 
       - name: compile mcfost
         if: ${{ matrix.compiler == 'gfortran' }}
@@ -72,35 +74,6 @@ jobs:
       MCFOST_INSTALL: /opt/local
     steps:
       - uses: actions/checkout@v2
-
-      # hdf5.mod file is located at /usr/lib64/gfortran/modules/ on almalinux
-      - name: install hdf5 for gnu build
-        if: ${{ matrix.toolchain.compiler == 'gfortran' }}
-        run: |
-          dnf install -y sudo wget epel-release
-          dnf install -y hdf5-static redhat-lsb-core
-          cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
-
-      - name: install hdf5 for intel build
-        if: ${{ matrix.toolchain.compiler == 'ifort' }}
-        run: |
-          export CC=icc
-          export FC=ifort
-          export CXX=icpc
-          export CFLAGS=""
-          wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
-          echo "Compiling HDF5 ..."
-          tar xjvf hdf5-1.10.5.tar.bz2
-          cd hdf5-1.10.5
-          mkdir -p "$HOME/hdf5_install_tmp"
-          ./configure --prefix="$HOME/hdf5_install_tmp" --enable-fortran --disable-shared
-          make install
-          \cp "$HOME/hdf5_install_tmp/lib/libhdf5.a" "$HOME/hdf5_install_tmp/lib/libhdf5_fortran.a" /usr/lib/
-          mkdir /usr/include/hdf5
-          \cp "$HOME"/hdf5_install_tmp/include/*.h /usr/include/hdf5/
-          \cp "$HOME"/hdf5_install_tmp/include/*.mod /usr/include/
-          echo "Done"
-
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,6 +66,9 @@ jobs:
 
       - run: git config --global --add safe.directory $PWD
 
+      - name: zlib version
+        run: zlib --version
+
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,6 +64,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: check python
+        run: python --version
+
       - run: git config --global --add safe.directory $PWD
 
       - name: build and install dependencies

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -74,6 +74,7 @@ jobs:
         if: ${{ matrix.toolchain.compiler == 'ifort' }}
         run: |
           python --version
+          apt-get update
           apt-get install python3-pip
           pip --version
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,35 +66,6 @@ jobs:
 
       - run: git config --global --add safe.directory $PWD
 
-      - name: zlib check
-        if: ${{ matrix.toolchain.compiler == 'ifort' }}
-        run: |
-          apt-get update
-          apt-get install zlib1g-dev -y
-          dpkg -L zlib1g-dev
-          echo "char inflateEnd ();" >> ctest.c
-          echo "int main (void)" >> ctest.c
-          echo "{" >> ctest.c
-          echo "       return inflateEnd ();" >> ctest.c
-          echo "}" >> ctest.c
-          cat ctest.c
-          gcc ctest.c -o testcompile -lz
-
-      - name: cfitsio test
-        if: ${{ matrix.toolchain.compiler == 'ifort' }}
-        run: |
-          wget -N http://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.3.0.tar.gz
-          echo "Compiling CFITSIO ..."
-          tar xzvf cfitsio-4.3.0.tar.gz
-          mv cfitsio-4.3.0 cfitsio
-          cd cfitsio
-          ./configure --enable-ssse3 --disable-curl
-          
-          make
-          \cp libcfitsio.a ../lib
-          cd ~1
-          echo "Done"
-
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux
         with:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -36,7 +36,6 @@ jobs:
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           tree /Volumes
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          hdiutil detach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
@@ -79,8 +78,8 @@ jobs:
           apt-get install -y libhdf5-dev
           dpkg -L libhdf5-dev
           cp "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a" "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_fortran.a" /usr/lib/
-          cp "/home/runner/work/include/hdf5/serial/*.h" /usr/include/hdf5/
-          cp "/home/runner/work/include/hdf5/serial/*.mod" /usr/include/
+          cp "/usr/include/hdf5/serial/*.h" /usr/include/hdf5/
+          cp "/usr/include/hdf5/serial/*.mod" /usr/include/
           
 
       - run: git config --global --add safe.directory $PWD

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,9 +31,10 @@ jobs:
       - name: install intel compilers
         if: ${{ matrix.compiler == 'ifort' }}
         run: |
+          brew install tree
           sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
           hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-          ls /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline
+          tree /Volumes
           sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/install.sh --silent --eula accept
           hdiutil detach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
       - name: install dependencies
@@ -76,6 +77,10 @@ jobs:
           add-apt-repository universe
           apt-get update
           apt-get install -y libhdf5-dev
+          cp "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.a" "/usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5_fortran.a" /usr/lib/
+          cp "/usr/include/hdf5/serial/*.h" /usr/include/hdf5/
+          cp "/usr/include/hdf5/serial/*.mod" /usr/include/
+          
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -66,8 +66,8 @@ jobs:
 
       - run: git config --global --add safe.directory $PWD
 
-      - name: zlib version
-        run: zlib --version
+      - name: zlib check
+        run: which zlib
 
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -39,17 +39,20 @@ jobs:
           echo "Do we have ifort?"
           which ifort
 
-
-        #cp $(find /opt/intel/oneapi/compiler/ | grep "icc$") /usr/local/include
-
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
       - name: compile mcfost
+        if: ${{ matrix.compiler == 'gfortran' }}
+        working-directory: src
+        run: make all
+
+      - name: compile mcfost (intel)
+        if: ${{ matrix.compiler == 'ifort' }}
         working-directory: src
         run: |
           which ifort
-          source /opt/intel/oneapi/setvars.sh
+          source /opt/intel/oneapi/setvars.sh 
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -31,7 +31,11 @@ jobs:
       - name: install intel compilers
         if: ${{ matrix.compiler == 'ifort' }}
         run:
-          sudo ./install.sh --silent --eula accept
+          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+          hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
+          ls /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline
+          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/install.sh --silent --eula accept
+          hdiutil detach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
 
@@ -71,7 +75,7 @@ jobs:
         run: |
           add-apt-repository universe
           apt-get update
-          apt-get install libhdf5-dev
+          apt-get install -y libhdf5-dev
 
       - run: git config --global --add safe.directory $PWD
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -71,11 +71,12 @@ jobs:
         run: |
           apt-get install zlib1g -y
           dpkg -L zlib1g
-          echo char inflateEnd (); >> ctest.c
-          echo int main (void) >> ctest.c
-          echo { >> ctest.c
-          echo        return inflateEnd (); >> ctest.c
-          echo } >> ctest.c
+          echo "char inflateEnd ();" >> ctest.c
+          echo "int main (void)" >> ctest.c
+          echo "{" >> ctest.c
+          echo "       return inflateEnd ();" >> ctest.c
+          echo "}" >> ctest.c
+          cat ctest.c
           gcc ctest.c -o testcompile -lz
 
       - name: cfitsio test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -28,17 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: install intel compilers
-        if: ${{ matrix.compiler == 'ifort' }}
-        run: |
-          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2fbce033-15f4-4e13-8d14-f5a2016541ce/m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-          sudo wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ebba13f8-1690-4d30-9d43-1e2fa2d536cd/m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
-          hdiutil attach m_fortran-compiler-classic_p_2023.2.0.49001_offline.dmg
-          sudo /Volumes/m_fortran-compiler-classic_p_2023.2.0.49001_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          hdiutil attach m_cpp-compiler-classic_p_2023.2.0.48999_offline.dmg
-          sudo /Volumes/m_cpp-compiler-classic_p_2023.2.0.48999_offline/bootstrapper.app/Contents/MacOS/install.sh --silent --eula accept
-          cp /opt/intel/oneapi/compiler/2023.2.0/mac/bin/intel64/ifort /usr/local/include
-
       - name: install dependencies
         uses: ./.github/actions/dependencies/macos
         with:
@@ -79,6 +68,8 @@ jobs:
 
       - name: build and install dependencies
         uses: ./.github/actions/dependencies/linux
+        with:
+          compiler: ${{ matrix.toolchain.compiler }}
 
       - name: compile mcfost
         working-directory: src


### PR DESCRIPTION
Added workflows for intel compilers (i.e. ifort) for linux and macos. These run alongside the existing actions for gnu compilers. The intel compilers take a while to load onto the runners and require building hdf5 from source, so the overall build/test time is a fair bit longer.