### PR TITLE
Combined matrix strategy in build action

### DIFF
--- a/.github/actions/dependencies/linux/action.yml
+++ b/.github/actions/dependencies/linux/action.yml
@@ -10,16 +10,16 @@ runs:
 
     # hdf5.mod file is located at /usr/lib64/gfortran/modules/ on almalinux
     - name: install hdf5 for gnu build
-      if: ${{ matrix.toolchain.compiler == 'gfortran' }}
+      if: ${{ matrix.compiler == 'gfortran' }}
       shell: bash
       run: |
         dnf install -y sudo wget epel-release
         dnf install -y hdf5-static redhat-lsb-core
-        cd /usr/include && ln -s /usr/lib64/gfortran/modules/* .
+        cd $HDF5_DIR/include && ln -s /usr/lib64/gfortran/modules/* .
 
     # hdf5 needs to be built from sources for intel compilers
     - name: install hdf5 for intel build
-      if: ${{ matrix.toolchain.compiler == 'ifort' }}
+      if: ${{ matrix.compiler == 'ifort' }}
       shell: bash
       env:
         CC: icc
@@ -30,11 +30,11 @@ runs:
         wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
         tar xjvf hdf5-1.10.5.tar.bz2
         cd hdf5-1.10.5
-        ./configure --prefix="/usr/local" --enable-fortran --disable-shared
+        ./configure --prefix=$HDF5_DIR --enable-fortran --disable-shared
         make install
 
     - name: get zlib dev libraries
-      if: ${{ matrix.toolchain.compiler == 'ifort' }}
+      if: ${{ matrix.compiler == 'ifort' }}
       shell: bash
       run: |
         apt-get update
@@ -46,7 +46,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ env.MCFOST_INSTALL }}
-        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}-${{ hashFiles('lib/install.sh') }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.compiler }}-${{ hashFiles('lib/install.sh') }}
 
     # Only do this (lengthy) setup if dependency cache not found
     - name: prepare mcfost environment

--- a/.github/actions/dependencies/macos/action.yml
+++ b/.github/actions/dependencies/macos/action.yml
@@ -28,7 +28,7 @@ runs:
           /usr/local/Cellar/cfitsio/
           /usr/local/Cellar/voro-dev/
           /usr/local/Cellar/sprng2/
-        key: mcfost-deps-${{ runner.os }}-${{ matrix.toolchain.compiler }}-${{ hashFiles('lib/install.sh') }}
+        key: mcfost-deps-${{ runner.os }}-${{ matrix.compiler }}-${{ hashFiles('lib/install.sh') }}
 
       # Symlinks to the path need to be created again after the cache is restored
     - name: add brew links
@@ -67,7 +67,7 @@ runs:
           wget -N https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2
           tar xjvf hdf5-1.10.5.tar.bz2
           cd hdf5-1.10.5
-          sudo CC=icc FC=ifort CXX=icpc ./configure --prefix=/usr/local --enable-fortran  --enable-cxx
+          sudo CC=icc FC=ifort CXX=icpc ./configure --prefix=$HDF5_DIR --enable-fortran  --enable-cxx
           sudo make
           sudo make install
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,9 +63,8 @@ jobs:
 
       - name: compile mcfost
         working-directory: src
-        shell: bash
+        shell: bash {0}
         run: |
-          set +o pipefail
           source /opt/intel/oneapi/setvars.sh || true
           make all
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,9 +52,6 @@ jobs:
 
       - run: git config --global --add safe.directory $PWD
 
-      - name: show GITHUB_ENV
-        run: echo $GITHUB_ENV
-
       # Actions doesn't seem to have a way to evaluate expressions in paths these 'uses' are hardcoded in
       - name: build and install dependencies (linux)
         if: matrix.os == 'linux'
@@ -64,16 +61,11 @@ jobs:
         if: matrix.os == 'macos'
         uses: ./.github/actions/dependencies/macos
 
-      - name: set up intel compiler env if needed
-        if: ${{ matrix.os == 'macos' && matrix.compiler == 'ifort' }}
-        working-directory: src
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          echo $GITHUB_ENV
-
       - name: compile mcfost
         working-directory: src
-        run: make all
+        run: |
+          source /opt/intel/oneapi/setvars.sh || true
+          make all
 
       - name: test
         uses: ./.github/actions/test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -64,7 +64,9 @@ jobs:
       - name: compile mcfost
         working-directory: src
         run: |
-          source /opt/intel/oneapi/setvars.sh || true
+          set +e
+          source /opt/intel/oneapi/setvars.sh
+          set -e
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,7 +65,9 @@ jobs:
         working-directory: src
         shell: bash -e {0}
         run: |
-          test -f /opt/intel/oneapi/setvars.sh || source /opt/intel/oneapi/setvars.sh
+          set +e
+          test -f /opt/intel/oneapi/setvars.sh && source /opt/intel/oneapi/setvars.sh
+          set -e
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: src
         shell: bash -e {0}
         run: |
-          source /opt/intel/oneapi/setvars.sh || true
+          test -f /opt/intel/oneapi/setvars.sh && source /opt/intel/oneapi/setvars.sh
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,10 +63,9 @@ jobs:
 
       - name: compile mcfost
         working-directory: src
+        shell: bash
         run: |
-          set +e
-          source /opt/intel/oneapi/setvars.sh
-          set -e
+          source /opt/intel/oneapi/setvars.sh || true
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -52,6 +52,9 @@ jobs:
 
       - run: git config --global --add safe.directory $PWD
 
+      - name: show GITHUB_ENV
+        run: echo $GITHUB_ENV
+
       # Actions doesn't seem to have a way to evaluate expressions in paths these 'uses' are hardcoded in
       - name: build and install dependencies (linux)
         if: matrix.os == 'linux'
@@ -61,17 +64,16 @@ jobs:
         if: matrix.os == 'macos'
         uses: ./.github/actions/dependencies/macos
 
-      - name: compile mcfost
-        if: ${{ !(matrix.os == 'macos' && matrix.compiler == 'ifort') }}
-        working-directory: src
-        run: make all
-
-      - name: compile mcfost (macos w/ ifort)
+      - name: set up intel compiler env if needed
         if: ${{ matrix.os == 'macos' && matrix.compiler == 'ifort' }}
         working-directory: src
         run: |
           source /opt/intel/oneapi/setvars.sh
-          make all   
+          echo something
+
+      - name: compile mcfost
+        working-directory: src
+        run: make all
 
       - name: test
         uses: ./.github/actions/test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: compile mcfost
         working-directory: src
-        shell: bash {0}
+        shell: bash -e {0}
         run: |
           source /opt/intel/oneapi/setvars.sh || true
           make all

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -69,7 +69,7 @@ jobs:
         working-directory: src
         run: |
           source /opt/intel/oneapi/setvars.sh
-          echo something
+          echo $GITHUB_ENV
 
       - name: compile mcfost
         working-directory: src

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -15,63 +15,63 @@ env:
   SKIP_HDF5: yes
 
 jobs:
-  macos:
+  build-and-test:
     strategy:
+      fail-fast: false
       matrix:
+        os: [linux, macos]
         compiler: [gfortran, ifort]
         openmp: [yes, no]
-    runs-on: macos-12
+
+        include:
+          # Associate specific os versions with our os tags
+          - os: linux
+            os-version: ubuntu-22.04
+          - os: macos
+            os-version: macos-12
+          
+          # macos needs null container to avoid loading docker; set linux containers as desired
+          - container: null
+          - os: linux
+            compiler: gfortran
+            container: "quay.io/pypa/manylinux_2_28_x86_64"
+          - os: linux
+            compiler: ifort
+            container: "intel/oneapi-hpckit:2023.2-devel-ubuntu22.04"
+
+    runs-on: ${{ matrix.os-version }}
+    container: ${{ matrix.container }}
     env:
       SYSTEM: ${{ matrix.compiler }}
       HDF5_DIR: /usr/local
       MCFOST_INSTALL: /usr/local
       OPENMP: ${{ matrix.openmp }}
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: install dependencies
-        uses: ./.github/actions/dependencies/macos
-
-      - name: compile mcfost (gnu)
-        if: ${{ matrix.compiler == 'gfortran' }}
-        working-directory: src
-        run: make all
-
-      - name: compile mcfost (intel)
-        if: ${{ matrix.compiler == 'ifort' }}
-        working-directory: src
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          make all
-
-      - name: test
-        uses: ./.github/actions/test
-
-  linux:
-    strategy:
-      matrix:
-        toolchain:
-          - {compiler: gfortran, container: quay.io/pypa/manylinux_2_28_x86_64}
-          - {compiler: ifort, container: "intel/oneapi-hpckit:2023.2-devel-ubuntu22.04"}
-        openmp: [yes, no]
-    runs-on: ubuntu-22.04
-    container: ${{ matrix.toolchain.container }}
-    env:
-      SYSTEM: ${{ matrix.toolchain.compiler }}
-      HDF5_DIR: /usr
-      MCFOST_INSTALL: /opt/local
-      OPENMP: ${{ matrix.openmp }}
+    
     steps:
       - uses: actions/checkout@v2
 
       - run: git config --global --add safe.directory $PWD
 
-      - name: build and install dependencies
+      # Actions doesn't seem to have a way to evaluate expressions in paths these 'uses' are hardcoded in
+      - name: build and install dependencies (linux)
+        if: matrix.os == 'linux'
         uses: ./.github/actions/dependencies/linux
 
+      - name: build and install dependencies (macos)
+        if: matrix.os == 'macos'
+        uses: ./.github/actions/dependencies/macos
+
       - name: compile mcfost
+        if: ${{ !(matrix.os == 'macos' && matrix.compiler == 'ifort') }}
         working-directory: src
         run: make all
+
+      - name: compile mcfost (macos w/ ifort)
+        if: ${{ matrix.os == 'macos' && matrix.compiler == 'ifort' }}
+        working-directory: src
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          make all   
 
       - name: test
         uses: ./.github/actions/test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,7 +65,7 @@ jobs:
         working-directory: src
         shell: bash -e {0}
         run: |
-          test -f /opt/intel/oneapi/setvars.sh && source /opt/intel/oneapi/setvars.sh
+          test -f /opt/intel/oneapi/setvars.sh || source /opt/intel/oneapi/setvars.sh
           make all
 
       - name: test

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,6 +65,7 @@ jobs:
         working-directory: src
         shell: bash
         run: |
+          set +o pipefail
           source /opt/intel/oneapi/setvars.sh || true
           make all
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -65,9 +65,7 @@ jobs:
         working-directory: src
         shell: bash -e {0}
         run: |
-          set +e
-          test -f /opt/intel/oneapi/setvars.sh && source /opt/intel/oneapi/setvars.sh
-          set -e
+          [ ! "$SETVARS_COMPLETED" == 1 ] && test -f /opt/intel/oneapi/setvars.sh && . /opt/intel/oneapi/setvars.sh
           make all
 
       - name: test


### PR DESCRIPTION
Reorganised test-suite.yml so everything runs in a single job with just one matrix strategy for os, compiler and openMP flags. It's a bit neater now. I've also made a couple of small changes so file paths are consistent between both os's. 

I've turned off fail-fast to prevent errors in one job from cancelling the others. Sometimes this hides errors in other jobs until you fix the first one but I can turn in back on if that's preferred.