### PR TITLE
Added a note in docs for potential gcc v14+ incompatibilities

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -127,6 +127,15 @@ https://github.com/cpinte/mcfost
 
   (depending on your gcc/g++ version).
 
+.. note:: Incompatiablities may present between mcfost and the latest gcc/gfortran versions (v14 or later).
+  If you encounter such compilation errors, consider manually fixing the versions of the related packages. For example, for anaconda users, try running::
+
+    $ conda create -n mcfost_make make cfitsio=4.3.0 hdf5 gcc=13.3.0 gxx=13.3.0 gfortran=13.3.0 autoconf zlib libgcc=13.3.0 libgfortran=13.3.0 conda-gcc-specs
+    
+    $ conda activate mcfost_make
+  
+  before continuing.
+
 4. If you wish to compile mcfost with the chemistry emulator, you also need to set::
 
      $ export MCFOST_XGBOOST=yes


### PR DESCRIPTION

Type of PR:
other

Description:
Added a note in docs for potential gcc v14+ incompatibilities during compilation from source.

Testing:
Describe how you have tested the change
opened the changed doc file on github to see if 

Did you run the botscheck that the code and comments follow the code of conduct? yes
(not sure what "botscheck" means, but I mannually went through the changes to ensure no harrassment content presents there.)

Did you update relevant documentation in the docs directory? yes
