### PR TITLE
Revert init_mcfost.f90

### DIFF
--- a/src/init_mcfost.f90
+++ b/src/init_mcfost.f90
@@ -1486,6 +1486,7 @@ subroutine initialisation_mcfost()
      case("-v_syst")
         i_arg = i_arg + 1
         call get_command_argument(i_arg,s)
+        read(s,*) v_syst
         i_arg = i_arg + 1
      case("-not_random_Voronoi")
         i_arg = i_arg + 1


### PR DESCRIPTION
Include read-in of systemic velocity from command line arguments

Type of PR:
Bug fix

Description:
Line was accidentally deleted

Testing:
Models work again once this is included
