### PR TITLE
Implementing turbulence as a function of local sound speed

### DIFF
--- a/src/init_mcfost.f90
+++ b/src/init_mcfost.f90
@@ -1486,6 +1486,7 @@ subroutine initialisation_mcfost()
      case("-v_syst")
         i_arg = i_arg + 1
         call get_command_argument(i_arg,s)
+        read(s,*) v_syst
         i_arg = i_arg + 1
      case("-not_random_Voronoi")
         i_arg = i_arg + 1

--- a/src/molecular_emission.f90
+++ b/src/molecular_emission.f90
@@ -157,6 +157,9 @@ subroutine init_Doppler_profiles(imol)
      ! Utilisation de la temperature LTE de la poussiere comme temperature cinetique
      ! WARNING : c'est pas un sigma mais un delta, cf Cours de Boisse p47
      ! Consistent avec benchmark
+     if (trim(v_turb_unit) == "cs") then
+        v_turb(icell) = sqrt((kb*Tcin(icell) / (masse_mol_gaz * g_to_kg))) * v_turb(icell)
+     endif
      sigma2 =  2.0_dp * (kb*Tcin(icell) / (masse_mol * g_to_kg)) + v_turb(icell)**2
      v_line(icell) = sqrt(sigma2)
 

--- a/src/read_param.f90
+++ b/src/read_param.f90
@@ -446,9 +446,7 @@ contains
     read(1,*) vitesse_turb, v_turb_unit
     if (v_turb_unit(1:2) == "km") then
        vitesse_turb = vitesse_turb * km_to_m ! Conversion en m.s-1
-    else if (trim(v_turb_unit) == "cs") then
-       call error("Turbulence velocity as a fraction of sound speed not implemented yet")
-    else
+    else if (trim(v_turb_unit) /= "cs") then
        call error("Turbulence velocity unit not recognised")
     endif
 


### PR DESCRIPTION
Input turbulence is in terms of the sound speed (e.g. 0.05 cs). Turbulence is multiplied by sound speed in the code and then used in the line width equation.
