### PR TITLE
fix #140 and skipping dead sink particles in phantom read

### DIFF
--- a/src/SPH2mcfost.f90
+++ b/src/SPH2mcfost.f90
@@ -127,7 +127,6 @@ contains
     ! Deleting particles/cells in masked areas (Hill sphere, etc)
     if (allocated(mask)) call delete_masked_particles()
 
-    call find_non_empty_cell()
 
     return
 
@@ -624,11 +623,14 @@ contains
        write(*,*) "Density was reduced by", density_factor, "in", n_force_empty, "cells surrounding the model, ie",&
             (1.0*n_force_empty)/n_cells * 100, "% of cells"
     endif
+    print*,"LVARIABLEDUST:",lvariable_dust
 
     if (ndusttypes >= 1) deallocate(a_SPH,log_a_SPH,rho_dust)
 
     write(*,*) 'Total  gas mass in model :',  real(sum(masse_gaz) * g_to_Msun),' Msun'
     write(*,*) 'Total dust mass in model :', real(sum(masse) * g_to_Msun),' Msun'
+
+    call find_non_empty_cell()
 
     return
 

--- a/src/SPH2mcfost.f90
+++ b/src/SPH2mcfost.f90
@@ -623,7 +623,6 @@ contains
        write(*,*) "Density was reduced by", density_factor, "in", n_force_empty, "cells surrounding the model, ie",&
             (1.0*n_force_empty)/n_cells * 100, "% of cells"
     endif
-    print*,"LVARIABLEDUST:",lvariable_dust
 
     if (ndusttypes >= 1) deallocate(a_SPH,log_a_SPH,rho_dust)
 

--- a/src/dust_prop.f90
+++ b/src/dust_prop.f90
@@ -944,6 +944,7 @@ subroutine opacite(lambda, p_lambda, no_scatt)
      endif !.not.lmono
   endif !lnLTE
 
+  if (icell_not_empty <= 0) call error("could not find a non empty cell")
   rho0 = masse(icell_not_empty)/volume(icell_not_empty) ! normalising by density in a non-empty cell
   if (rho0 < tiny_dp) call error("cannot normalise by density in first non-empty cell")
 

--- a/src/optical_depth.f90
+++ b/src/optical_depth.f90
@@ -215,6 +215,7 @@ subroutine integ_tau(lambda)
 
   if (.not.lvariable_dust) then
      icell = icell_not_empty
+     if (icell <= 0) call error("icell_not_empty is out of bounds.")
      if (kappa(icell1,lambda) * kappa_factor(icell) > tiny_real) then
         write(*,*) " Column density (g/cm^2)   = ", real(tau*(masse(icell)/(volume(icell)*AU_to_cm**3))/ &
              (kappa(icell1,lambda) * kappa_factor(icell)/AU_to_cm))

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -808,7 +808,7 @@ contains
 
     type(star_type), dimension(:), allocatable :: etoile_old
     integer  :: i,j,k,itypei,alloc_status,i_etoile, n_etoiles_old, ifile,n_skip,nsinkproperties
-    real(dp) :: xi,yi,zi,hi,vxi,vyi,vzi,T_gasi,rhogasi,rhodusti,gasfraci,dustfraci,totlum,qtermi,tbirth
+    real(dp) :: xi,yi,zi,hi,vxi,vyi,vzi,T_gasi,rhogasi,rhodusti,gasfraci,dustfraci,totlum,qtermi
     real(dp) :: ulength_scaled, umass_scaled, utime_scaled,udens,uerg_per_s,uWatt,ulength_au,ulength_m,usolarmass,uvelocity
     real(dp) :: vphi, vr, phi, cos_phi, sin_phi, r_cyl, r_cyl2, r_sph, G_phantom
     real(dp), allocatable :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -765,7 +765,7 @@ contains
   !*************************************************************************
 
   subroutine phantom_2_mcfost(np,nptmass,ntypes,ndusttypes,ldust_moments,n_files,dustfluidtype,xyzh, &
-       vxyzu,gastemperature,iphase,grainsize,dustfrac,nucleation,massoftype,xyzmh_ptmass,vxyz_ptmass,hfact,umass, &
+       vxyzu,gastemperature,iphase,grainsize,dustfrac,nucleation,massoftype,xyzmh_ptmass_in,vxyz_ptmass_in,hfact,umass, &
        utime, ulength,graindens,ndudt,dudt,ifiles, &
        n_SPH,x,y,z,h,vx,vy,vz,T_gas,particle_id, &
        SPH_grainsizes, massgas,massdust, rhogas,rhodust,dust_moments,extra_heating,ieos)
@@ -792,7 +792,7 @@ contains
     real(dp), dimension(ndusttypes),    intent(in) :: graindens
     real(dp), dimension(n_files,ntypes), intent(in) :: massoftype
     real(dp), intent(in) :: hfact,umass,utime,ulength
-    real(dp), dimension(:,:), intent(in) :: xyzmh_ptmass, vxyz_ptmass
+    real(dp), dimension(:,:), intent(in) :: xyzmh_ptmass_in, vxyz_ptmass_in
     real(dp), dimension(:,:), intent(inout), allocatable :: nucleation
     real(dp), dimension(:), intent(in) :: gastemperature
     integer, intent(in) :: ndudt
@@ -806,12 +806,12 @@ contains
     real(dp), dimension(:), allocatable, intent(out) :: SPH_grainsizes ! mum
     real, dimension(:), allocatable, intent(out) :: extra_heating
 
-
     type(star_type), dimension(:), allocatable :: etoile_old
-    integer  :: i,j,k,itypei,alloc_status,i_etoile, n_etoiles_old, ifile
-    real(dp) :: xi,yi,zi,hi,vxi,vyi,vzi,T_gasi,rhogasi,rhodusti,gasfraci,dustfraci,totlum,qtermi
+    integer  :: i,j,k,itypei,alloc_status,i_etoile, n_etoiles_old, ifile,n_skip,nsinkproperties
+    real(dp) :: xi,yi,zi,hi,vxi,vyi,vzi,T_gasi,rhogasi,rhodusti,gasfraci,dustfraci,totlum,qtermi,tbirth
     real(dp) :: ulength_scaled, umass_scaled, utime_scaled,udens,uerg_per_s,uWatt,ulength_au,ulength_m,usolarmass,uvelocity
     real(dp) :: vphi, vr, phi, cos_phi, sin_phi, r_cyl, r_cyl2, r_sph, G_phantom
+    real(dp), allocatable :: xyzmh_ptmass(:,:),vxyz_ptmass(:,:)
 
     logical :: use_dust_particles = .false. ! 2-fluid: choose to use dust
     logical :: lupdate_photosphere
@@ -993,25 +993,40 @@ contains
        ldudt_implicit = .false.
     endif
 
+    allocate(xyzmh_ptmass,source=xyzmh_ptmass_in)
+    allocate(vxyz_ptmass,source=vxyz_ptmass_in)
+    nsinkproperties = size(xyzmh_ptmass_in,dim=1)
     n_etoiles_old = n_etoiles
     if (lignore_sink) then
        n_etoiles = 0
     else
        write(*,*) "# Stars/planets:"
        n_etoiles = 0
+       n_skip    = 0
        do i=1,nptmass
-          n_etoiles = n_etoiles + 1
-          if (real(xyzmh_ptmass(4,i)) * scale_mass_units_factor > 0.013) then
-             write(*,*) "Star   #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * ulength_au), "au, M=", &
-                  real(xyzmh_ptmass(4,i) * usolarmass), "Msun, Mdot=", &
-                  real(xyzmh_ptmass(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
+          if (xyzmh_ptmass_in(4,i) < 0.001 .or. xyzmh_ptmass_in(5,i)>0.01) then
+             n_skip = n_skip + 1
           else
-             write(*,*) "Planet #", i, "xyz=", real(xyzmh_ptmass(1:3,i) * ulength_au), "au, M=", &
-                  real(xyzmh_ptmass(4,i) * GxMsun/GxMjup * usolarmass), "Mjup, Mdot=", &
-                  real(xyzmh_ptmass(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
+             n_etoiles = n_etoiles + 1
+             if (n_etoiles /= i) then
+                ! Move live particle to front of array
+                xyzmh_ptmass(:,n_etoiles) = xyzmh_ptmass_in(:,i)
+                vxyz_ptmass(:,n_etoiles)  = vxyz_ptmass_in(:,i)
+             endif
+             if (real(xyzmh_ptmass_in(4,i)) * usolarmass > 0.013) then
+                write(*,*) "Star   #", i, "xyz=", real(xyzmh_ptmass_in(1:3,i) * ulength_au), "au, M=", &
+                      real(xyzmh_ptmass_in(4,i) * usolarmass), "Msun, Mdot=", &
+                      real(xyzmh_ptmass_in(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
+             else
+                write(*,*) "Planet #", i, "xyz=", real(xyzmh_ptmass_in(1:3,i) * ulength_au), "au, M=", &
+                      real(xyzmh_ptmass_in(4,i) * GxMsun/GxMjup * usolarmass), "Mjup, Mdot=", &
+                      real(xyzmh_ptmass_in(16,i) * usolarmass / utime_scaled * year_to_s ), "Msun/yr"
+             endif
+             if (i>1) write(*,*)  "       distance=", real(norm2(xyzmh_ptmass_in(1:3,i) - xyzmh_ptmass_in(1:3,1))*ulength_au), "au"
           endif
-          if (i>1) write(*,*)  "       distance=", real(norm2(xyzmh_ptmass(1:3,i) - xyzmh_ptmass(1:3,1))*ulength_au), "au"
        enddo
+       if (n_skip > 0) write(*,*) "Skipped ", n_skip," dead sink particles..."
+       if (n_etoiles_old == 0) n_etoiles_old = n_etoiles
     endif
 
     if (lupdate_velocities) then
@@ -1132,15 +1147,15 @@ contains
        deallocate(etoile_old)
 
        if (n_etoiles > 0) then
-          etoile(:)%x = xyzmh_ptmass(1,:) * ulength_au
-          etoile(:)%y = xyzmh_ptmass(2,:) * ulength_au
-          etoile(:)%z = xyzmh_ptmass(3,:) * ulength_au
-
-          etoile(:)%vx = vxyz_ptmass(1,:) * uvelocity
-          etoile(:)%vy = vxyz_ptmass(2,:) * uvelocity
-          etoile(:)%vz = vxyz_ptmass(3,:) * uvelocity
-
-          etoile(:)%M = xyzmh_ptmass(4,:) * usolarmass
+         do i=1,n_etoiles
+             etoile(i)%x = xyzmh_ptmass(1,i) * ulength_au
+             etoile(i)%y = xyzmh_ptmass(2,i) * ulength_au
+             etoile(i)%z = xyzmh_ptmass(3,i) * ulength_au
+             etoile(i)%vx = vxyz_ptmass(1,i) * uvelocity
+             etoile(i)%vy = vxyz_ptmass(2,i) * uvelocity
+             etoile(i)%vz = vxyz_ptmass(3,i) * uvelocity
+             etoile(i)%M = xyzmh_ptmass(4,i) * usolarmass
+         enddo
 
           do i=1, n_etoiles
              if (.not.etoile(i)%force_Mdot) then
@@ -1195,6 +1210,9 @@ contains
     endif
 
     if (lheader_only) stop
+
+    if (allocated(xyzmh_ptmass)) deallocate(xyzmh_ptmass)
+    if (allocated(vxyz_ptmass)) deallocate(vxyz_ptmass)
 
     return
 

--- a/src/read_phantom.f90
+++ b/src/read_phantom.f90
@@ -1004,7 +1004,7 @@ contains
        n_etoiles = 0
        n_skip    = 0
        do i=1,nptmass
-          if (xyzmh_ptmass_in(4,i) < 0.001 .or. xyzmh_ptmass_in(5,i)>0.01) then
+          if (xyzmh_ptmass_in(4,i) < 0.) then
              n_skip = n_skip + 1
           else
              n_etoiles = n_etoiles + 1


### PR DESCRIPTION
Type of PR:
Bug fix 

Description:
- fixing #140 caused by a missing call of `find_non_empty_cell` when called through the phantom API. 
- merged sink particles in phantom are denoted by negative mass. These particles are now skipped by mcfost.

Testing:
command line mode and through API agree.

Did you run the botscheck that the code and comments follow the code of conduct? no

Did you update relevant documentation in the docs directory? no
