### PR TITLE
major bug fixed in column density calculation for photodissociation/photodesorption

### DIFF
--- a/src/molecular_emission.f90
+++ b/src/molecular_emission.f90
@@ -966,7 +966,7 @@ function compute_vertical_CD(icell) result(CD)
      icell0 = next_cell
      x0 = x1 ; y0 = y1 ; z0 = z1
      call cross_cell(x0,y0,z0, u,v,w,  icell0, previous_cell, x1,y1,z1, next_cell, l, l_contrib, l_void_before)
-     CD = CD + (l_contrib * AU_to_m) * densite_gaz(icell) ! part.m^-2
+     CD = CD + (l_contrib * AU_to_m) * densite_gaz(icell0) ! part.m^-2
   enddo
 
   return


### PR DESCRIPTION

Type of PR:
Urgent bug fix

Description:
Column density was not looping over cells correctly in compute_vertical_CD - using constant density, not density of each cell, causing mismatch between results from compute_vertical_CD and compute_column in optical_depth.f90. This was making photodissociation and photodesorption happen at much lower column densities (about factor 10) than they should be

Testing:
Compared results of two subroutines against each other, regions of CO now line up with expected threshold column densities

Did you run the botscheck that the code and comments follow the code of conduct? no

Did you update relevant documentation in the docs directory? no
