### PR TITLE
implement dust sublimation for multiple stars on Voronoi grid

### DIFF
--- a/docs/parameter_file.rst
+++ b/docs/parameter_file.rst
@@ -225,7 +225,9 @@ Disk physics
   hydrostatic equilibrium assuming Tgas = Tdust
 
 * ``sublimate_dust``: this option will iteratively remove the dust if the
-  temperature reaches the dust sublimation temperature
+  temperature reaches the dust sublimation temperature. On Voronoi grids,
+  dust is removed inside the sublimation radius of each star and in
+  cells where the dust temperature exceeds the sublimation temperature.
 
 * ``viscous_heating``: (*work in progress*) includes additional heating
   source due to viscous accretion (note that it does not account for the

--- a/src/disk_physics.f90
+++ b/src/disk_physics.f90
@@ -232,6 +232,7 @@ subroutine sublimate_dust()
      endif
   enddo
 
+  call find_non_empty_cell()
   mass = real(sum(dust_mass) * g_to_Msun)
   write(*,*) 'New total dust mass in model :', mass,' Msun'
 

--- a/src/disk_physics.f90
+++ b/src/disk_physics.f90
@@ -3,17 +3,19 @@ module disk_physics
   use grains
   use mcfost_env
   use dust_prop
-  use density, only : gas_density, dust_density_o_n_grains
+  use density, only : dust_density_o_n_grains, dust_mass, find_non_empty_cell
   use constants
-  use stars, only : star_spectrum
+  use stars, only : star_spectrum, prob_E_star
   use messages
   use wavelengths
   use temperature
   use cylindrical_grid
+  use parameters
 
   implicit none
 
   character(len=32) :: sublimationFile = "sublimation_radius.txt"
+  real(kind=dp), parameter :: sub_factor = 1.6_dp
 
 contains
 
@@ -21,10 +23,8 @@ contains
 subroutine compute_othin_sublimation_radius()
   ! In the optically thin case, depends only on the temperature (and spectrum) of the star
 
-  implicit none
-
   real(kind=dp) :: E_dust, E_etoile, coeff_exp, cst_wl, sublimation_radius
-  real :: cst, wl, delta_wl
+  real :: cst, wl, delta_wl, star_flux
   integer :: lambda, icell, i
 
   E_dust = 0.0
@@ -45,29 +45,31 @@ subroutine compute_othin_sublimation_radius()
   enddo
   E_dust = E_dust * 2.0*pi*hp*c_light**2
 
-  ! Emission etoiles
+  if (E_dust < tiny_real) then
+     call error("Sublimation radius : opacity is not defined yet", &
+          msg2="Maybe the parameter file is old ?")
+  endif
+
+  ! Emission etoiles: per-star flux via prob_E_star * star_spectrum
   do i=1, n_stars
      E_etoile = 0.0
      do lambda=1, n_lambda
-        E_etoile = E_etoile + kappa_abs_LTE(icell,lambda) * star_spectrum(lambda) / ( 4*pi * AU_to_m**2)
+        star_flux = prob_E_star(lambda,i) * star_spectrum(lambda)
+        E_etoile = E_etoile + kappa_abs_LTE(icell,lambda) * star_flux / ( 4*pi * AU_to_m**2)
      enddo
-
-     if (E_dust < tiny_real) then
-        call error("Sublimation radius : opacity is not defined yet", &
-             msg2="Maybe the parameter file is old ?")
-     endif
      star(i)%othin_sublimation_radius = sqrt(E_etoile/E_dust)
+     write(*,'(a,i0,a,f6.3,a)') "Optically thin sublimation radius (star #", i, ") = ", &
+          real(star(i)%othin_sublimation_radius), " AU"
   enddo
 
-  if (.not.lVoronoi) then
-     sublimation_radius = real(star(1)%othin_sublimation_radius)
-     write(*,*) "Optically thin sublimation radius =", real(sublimation_radius), "AU"
-     sublimation_radius = sublimation_radius * 1.6
+  open(unit=1,file=trim(data_dir)//"/"//trim(sublimationFile),status="replace")
+  write(1,*) star(:)%othin_sublimation_radius
+  close(1)
 
-     open(unit=1,file=trim(data_dir)//"/"//trim(sublimationFile),status="replace")
-     write(1,*) star(:)%othin_sublimation_radius
-     close(1)
-
+  if (lVoronoi) then
+     call sublimate_dust_Voronoi_radius(sub_factor)
+  else
+     sublimation_radius = real(star(1)%othin_sublimation_radius) * sub_factor
      call set_sublimation_radius(sublimation_radius)
   endif
 
@@ -110,10 +112,15 @@ subroutine read_sublimation_radius()
   write(*,*) "Reading sublimation file : ./data_th/"//trim(sublimationfile)
 
   open(unit=1,file=trim(root_dir)//"/"//trim(seed_dir)//"/data_th/"//trim(sublimationfile), status="old")
-  read(1,*) sublimation_radius
+  read(1,*) star(:)%othin_sublimation_radius
   close(unit=1)
 
-  call set_sublimation_radius(sublimation_radius)
+  if (lVoronoi) then
+     call sublimate_dust_Voronoi_radius(sub_factor)
+  else
+     sublimation_radius = real(star(1)%othin_sublimation_radius) * sub_factor
+     call set_sublimation_radius(sublimation_radius)
+  endif
 
   return
 
@@ -121,52 +128,111 @@ end subroutine read_sublimation_radius
 
 !**********************************************************************
 
+subroutine sublimate_dust_Voronoi_radius(rsub_factor)
+  ! Remove dust inside the sublimation radius of each star on a Voronoi grid.
+  ! Radius for star i is rsub_factor * star(i)%othin_sublimation_radius.
+
+  use Voronoi_grid, only : Voronoi
+
+  real(kind=dp), intent(in) :: rsub_factor
+
+  integer :: icell, istar, n_delete_star, n_delete_total
+  real(kind=dp) :: dx, dy, dz, d2, r2, sublimation_radius
+  logical, dimension(:), allocatable :: lcleared
+
+  allocate(lcleared(n_cells))
+  lcleared = .false.
+  n_delete_total = 0
+
+  do istar=1, n_stars
+     sublimation_radius = real(star(istar)%othin_sublimation_radius, kind=dp) * rsub_factor
+     r2 = sublimation_radius**2
+     n_delete_star = 0
+
+     write(*,'(a,i0,a,f6.3,a,f6.3,a,f3.1,a)') "Star #", istar, ": sublimation radius = ", &
+          real(sublimation_radius), " AU (= ", real(star(istar)%othin_sublimation_radius), &
+          " x ", real(rsub_factor), ")"
+
+     do icell=1, n_cells
+        ! Skip star sink cells (no dust)
+        if (Voronoi(icell)%is_star) cycle
+
+        dx = Voronoi(icell)%xyz(1) - star(istar)%x
+        if (abs(dx) > sublimation_radius) cycle
+        dy = Voronoi(icell)%xyz(2) - star(istar)%y
+        if (abs(dy) > sublimation_radius) cycle
+        dz = Voronoi(icell)%xyz(3) - star(istar)%z
+        if (abs(dz) > sublimation_radius) cycle
+
+        d2 = dx**2 + dy**2 + dz**2
+        if (d2 < r2) then
+           dust_density_o_n_grains(:,icell) = 0.0
+           dust_mass(icell) = 0.0
+           n_delete_star = n_delete_star + 1
+           if (.not.lcleared(icell)) then
+              lcleared(icell) = .true.
+              n_delete_total = n_delete_total + 1
+           endif
+        endif
+     enddo
+
+     write(*,'(a,i0,a)') "  -> removing dust in ", n_delete_star, " cells"
+  enddo
+
+  write(*,'(a,i0)') "Total cells cleared inside sublimation radii: ", n_delete_total
+  deallocate(lcleared)
+  call find_non_empty_cell()
+
+  return
+
+end subroutine sublimate_dust_Voronoi_radius
+
+!**********************************************************************
+
 subroutine sublimate_dust()
   ! Remove grains whose temperature exceeds the sublimation temperature
-  ! C. Pinte
-  ! 07/08/12
+  ! C. Pinte 07/08/12
+  ! D. Price 25/06/26: updated to work with all grid types (esp. Voronoi)
 
-  integer :: i, j, pk, icell, k, ipop, l
+  integer :: icell, k, ipop, p_k
   real :: mass
+  logical :: lchanged
 
   write(*,*) "Sublimating dust"
 
-  do i=1,n_rad
-     do j=j_start,nz
-        if (j==0) cycle
-        do pk=1,n_az
-           icell = cell_map(i,j,pk)
+  do icell=1, n_cells
+     lchanged = .false.
+     do k=1, n_grains_tot
+        ipop = grain(k)%pop
 
-           ! Cas LTE
-           do k=1,n_grains_tot
-              ipop = grain(k)%pop
-
-              if (.not.dust_pop(ipop)%is_PAH) then
-                 if (Tdust(icell) > dust_pop(ipop)%T_sub) then
-                    dust_density_o_n_grains(k,icell) = 0.0
-                 endif
-              endif
-           enddo
-
-
-        enddo !pk
-     enddo !j
-  enddo !i
-
-  mass = 0.0
-  do i=1,n_rad
-     do j=j_start,nz
-        if (j==0) cycle
-        do k=1,n_az
-           icell = cell_map(i,j,k)
-           do l=1,n_grains_tot
-              mass=mass + dust_density_o_n_grains(l,icell) * n_grains(l) * M_grain(l) * (volume(icell) * AU3_to_cm3)
-           enddo
-        enddo
+        if (.not.dust_pop(ipop)%is_PAH) then
+           if (Tdust(icell) > dust_pop(ipop)%T_sub) then
+              ! (n_grains_tot,n_cells) if lvariable_dust, else (n_zones,n_cells)
+              p_k = merge(k, grain(k)%zone, lvariable_dust)
+              dust_density_o_n_grains(p_k,icell) = 0.0
+              lchanged = .true.
+           endif
+        endif
      enddo
-  enddo
-  mass =  mass/Msun_to_g
 
+     ! Keep dust_mass consistent with density (needed for kappa_factor when .not.lvariable_dust)
+     if (lchanged) then
+        if (lvariable_dust) then
+           dust_mass(icell) = 0.0
+           do k=1, n_grains_tot
+              dust_mass(icell) = dust_mass(icell) + dust_density_o_n_grains(k,icell) * n_grains(k) &
+                   * M_grain(k) * volume(icell) * AU3_to_cm3
+           enddo
+        else
+           ! Zone-indexed density: if wiped, mass is zero (SPH and analytic single-zone)
+           if (maxval(dust_density_o_n_grains(:,icell)) <= 0.0) then
+              dust_mass(icell) = 0.0
+           endif
+        endif
+     endif
+  enddo
+
+  mass = real(sum(dust_mass) * g_to_Msun)
   write(*,*) 'New total dust mass in model :', mass,' Msun'
 
 end subroutine sublimate_dust
@@ -181,8 +247,6 @@ subroutine equilibre_hydrostatique()
   !
   ! C. Pinte
   ! 25/09/07
-
-  implicit none
 
   real, dimension(nz) :: rho, ln_rho
   real :: dz, dz_m1, dTdz, fac1, fac2, M_stars, M_mol, total_sum, cst

--- a/src/dust_transfer.f90
+++ b/src/dust_transfer.f90
@@ -196,8 +196,10 @@ subroutine dust_transfer_sub()
 
      if (ldust_sublimation) then
         call read_sublimation_radius()
-        call define_grid()
-        call define_dust_density()
+        if (.not.lVoronoi) then
+           call define_grid()
+           call define_dust_density()
+        endif
      endif
 
      call prop_grains(1)
@@ -225,6 +227,12 @@ subroutine dust_transfer_sub()
      else ! Only the star is emitting
         Tdust=0.0
      endif !l_em_disk_image
+
+     ! Re-apply T-based sublimation so -img matches the thermal-run dust
+     if (ldust_sublimation) then
+        call sublimate_dust()
+        call opacity(1,1)
+     endif
 
   else ! not lmono
 
@@ -301,8 +309,10 @@ subroutine dust_transfer_sub()
 
         if (ldust_sublimation)  then
            call compute_othin_sublimation_radius()
-           call define_grid()
-           call define_dust_density()
+           if (.not.lVoronoi) then
+              call define_grid()
+              call define_dust_density()
+           endif
 
            if (ldisk_struct) call write_disk_struct(.false.,lwrite_column_density,lwrite_velocity)
 


### PR DESCRIPTION
Type of PR:
New physics

Description:
Dust sublimation now working with multiple stars on the Voronoi grid. The algorithm is the same, but computes a radius from each star for the optically thin dust sublimation radius, using the luminosity for that star.

Testing:
See comparison attached from post-processing of a simulation of DX Cha (1.66 micron image). Left is with dust sublimation, right is without. Seems to happily carve out a sublimation cavity correctly around each star.

Did you run the botscheck that the code and comments follow the code of conduct? no

Did you update relevant documentation in the docs directory? yes

<img width="1287" height="731" alt="image" src="https://github.com/user-attachments/assets/fe9eb6ed-ee59-4e1a-b191-0d23a31b8cef" />
